### PR TITLE
add: Security context constraints

### DIFF
--- a/ray-operator/config/openshift/kuberay-operator-image-patch.yaml
+++ b/ray-operator/config/openshift/kuberay-operator-image-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberay-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: kuberay-operator
+        image: $(image)

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+configMapGenerator:
+- name: ray-config
+  envs:
+    - params.env
+configurations:
+  - params.yaml
+
+vars:
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
+
+resources:
+- ray_operator_scc.yaml
+- ../default
+
+commonLabels:
+  app.kubernetes.io/name: kuberay
+  app.kubernetes.io/component: kuberay-operator

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -7,6 +7,7 @@ configMapGenerator:
 - name: ray-config
   envs:
     - params.env
+
 configurations:
   - params.yaml
 
@@ -18,6 +19,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
+- name: image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kuberay-operator-controller-image
 
 resources:
 - ray_operator_scc.yaml
@@ -26,3 +34,11 @@ resources:
 commonLabels:
   app.kubernetes.io/name: kuberay
   app.kubernetes.io/component: kuberay-operator
+
+patches:
+- path: kuberay-operator-image-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: kuberay-operator

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,0 +1,1 @@
+namespace=opendatahub

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,1 +1,2 @@
 namespace=opendatahub
+odh-kuberay-operator-controller-image=quay.io/kuberay/operator:v0.6.0

--- a/ray-operator/config/openshift/params.yaml
+++ b/ray-operator/config/openshift/params.yaml
@@ -1,0 +1,7 @@
+varReference:
+  - path: subjects[]/namespace
+    kind: ClusterRoleBinding
+  - path: users[]
+    kind: SecurityContextConstraints
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment

--- a/ray-operator/config/openshift/params.yaml
+++ b/ray-operator/config/openshift/params.yaml
@@ -1,6 +1,4 @@
 varReference:
-  - path: subjects[]/namespace
-    kind: ClusterRoleBinding
   - path: users[]
     kind: SecurityContextConstraints
   - path: spec/template/spec/containers[]/image

--- a/ray-operator/config/openshift/ray_operator_scc.yaml
+++ b/ray-operator/config/openshift/ray_operator_scc.yaml
@@ -1,0 +1,11 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: run-as-ray-user
+seLinuxContext:
+  type: MustRunAs
+runAsUser:
+  type: MustRunAs
+  uid: 1000
+users:
+  - 'system:serviceaccount:$(namespace):kuberay-operator'


### PR DESCRIPTION
## Why are these changes needed?

This pr adds the Kuberay SCC to the repository to be deployed. The changes are added to both the Kustomize deployments.

## Related issue number

closes https://github.com/red-hat-data-services/distributed-workloads/issues/15

## To check changes

Update the ray-operator/Makefile deploy to :
```
deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
	cd config/manager && $(KUSTOMIZE) edit set image kuberay/operator=${IMG}
	($(KUSTOMIZE) build config/openshift | kubectl create -f -) || ($(KUSTOMIZE) build config/openshift | kubectl replace -f -)
```


Kustomize:
  - From within the ray-operator directory, run `make deploy -e IMG=<your-image`
  
  Check to ensure the run-as-ray-user SCC has been applied correctly, and ensure Users is set in the correct namespace (opendatahub):
 ```
  Users:                                                                    │
   system:serviceaccount:opendatahub:kuberay-operator  
 ```
 
 Also ensure the ray-operator, and rbacs are applied within the `opendatahub` namespace.
 
## Checks

- [x]  I've made sure the tests are passing.
- Testing Strategy
    - [ ]  Unit tests
    - [x]  Manual tests
    - [ ]  This PR is not tested :(