### PR TITLE
add aggregator role for admin and editor

### DIFF
--- a/ray-operator/config/rbac/editor_role.yaml
+++ b/ray-operator/config/rbac/editor_role.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuberay-edit-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  - rayclusters
+  - rayservices
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/finalizers
+  - rayclusters/finalizers
+  - rayjobs/finalizers
+  - rayservices/status
+  - rayclusters/status
+  - rayjobs/status
+  verbs:
+  - get

--- a/ray-operator/config/rbac/kustomization.yaml
+++ b/ray-operator/config/rbac/kustomization.yaml
@@ -1,9 +1,11 @@
 resources:
+- editor_role.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - service_account.yaml
+- viewer_role.yaml
 
 commonLabels:
   app.kubernetes.io/name: kuberay

--- a/ray-operator/config/rbac/viewer_role.yaml
+++ b/ray-operator/config/rbac/viewer_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuberay-view-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  - rayclusters
+  - rayservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayservices/finalizers
+  - rayclusters/finalizers
+  - rayjobs/finalizers
+  - rayservices/status
+  - rayclusters/status
+  - rayjobs/status
+  verbs:
+  - get


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

user admin and editors dont have permissions for creating kuberay CRs by default. This will add a role which is automatically aggregated to users with these permissions in their namespaces.

## Related issue number

https://issues.redhat.com/browse/RHOAIENG-2184

## Checks

- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
