### PR TITLE
PATCH: Raise head pod memory limit to avoid test instability

### DIFF
--- a/ray-operator/test/e2e/support.go
+++ b/ray-operator/test/e2e/support.go
@@ -140,7 +140,7 @@ func headPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 					}).
 					WithLimits(corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("2G"),
+						corev1.ResourceMemory: resource.MustParse("3G"),
 					}))))
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Running KubeRay e2e tests on OpenShift with Red Hat KubeRay image seems to require more memory. Head node memory limit is sometimes reached in downstream tests.
By raising memory limit for Head node we should stabilize downstream tests.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
