### PR TITLE
Set FS group to MustRunAs for Ray SCC

### DIFF
--- a/ray-operator/config/openshift/ray_operator_scc.yaml
+++ b/ray-operator/config/openshift/ray_operator_scc.yaml
@@ -13,5 +13,7 @@ requiredDropCapabilities:
 runAsUser:
   type: MustRunAs
   uid: 1000
+fsGroup:
+  type: MustRunAs
 users:
   - 'system:serviceaccount:$(namespace):kuberay-operator'


### PR DESCRIPTION
## Why are these changes needed?

This makes volumes mounted into the Ray pods writable by the Ray processes.

## Checks

- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
