### PR TITLE
CARRY: Add upstream metadata to Kuberay manifests

### DIFF
--- a/ray-operator/config/openshift/component_metadata.yaml
+++ b/ray-operator/config/openshift/component_metadata.yaml
@@ -1,0 +1,4 @@
+releases:
+  - name: KubeRay
+    version: 1.2.2
+    repoUrl: https://github.com/ray-project/kuberay


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Added upstream metadata to Kuberay manifests. This PR can be merged after rebasing odh and rhds with kuberay 1.2.2 

## Related issue number

[RHOAIENG-15700](https://issues.redhat.com/browse/RHOAIENG-15700)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
