### PR TITLE
Add wei/pull config for auto upstream syncing

### DIFF
--- a/.github/pull.yaml
+++ b/.github/pull.yaml
@@ -1,0 +1,6 @@
+version: "1"
+rules:
+  - base: dev
+    upstream: ray-project:master
+    mergeMethod: hardreset
+conflictLabel: "merge-conflict"


### PR DESCRIPTION
## Why are these changes needed?
We want to sync ray-project/kuberay:master with odh/kuberay:dev regularly. wei/pull is used by other teams so I'm addiing a config file here