### PR TITLE
Update params.env to use konflux image

### DIFF
--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,2 +1,2 @@
 namespace=opendatahub
-odh-kuberay-operator-controller-image=quay.io/kuberay/operator:v1.3.2
+odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.3.2


### PR DESCRIPTION
Once again, no tests need to pass here, just pointing to the new konflux image. Creating PR for visibility

**IMPORTANT**: If for some reason something blows up, and I'm not around to fix it, I have a backup on [release-v1.3.2-backup](https://github.com/opendatahub-io/kuberay/tree/release-v1.3.2-backup).

If for some reason we do need to revert quickly, do the following: 
- check out the backup branch
- rename it to `release-v1.3.2`
- force push it to `opendatahub-io/kuberay:release-v1.3.2` to return to the old state

This will make it use the old upstream image we used to point to.