### PR TITLE
CARRY: RHOAIENG-26544 Disable Github actions workflows on draft PR

### DIFF
--- a/.github/workflows/consistency-check.yaml
+++ b/.github/workflows/consistency-check.yaml
@@ -6,6 +6,7 @@ on:
     - dev
     - release-*
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
     - '**'
 
@@ -14,6 +15,7 @@ jobs:
   ray-operator-verify-codegen:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -41,6 +43,7 @@ jobs:
   ray-operator-verify-api-docs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -65,6 +68,7 @@ jobs:
   ray-operator-verify-crd-rbac:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -100,6 +104,7 @@ jobs:
     needs: ray-operator-verify-crd-rbac
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -129,6 +134,7 @@ jobs:
     needs: ray-operator-verify-crd-rbac
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - '**'
   push:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
       - 'release-*'
@@ -16,6 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
         - name: Checkout code
           uses: actions/checkout@v3

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -6,6 +6,7 @@ on:
     - dev
     - release-*
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - '**'
 
@@ -13,6 +14,7 @@ jobs:
   lint:
     name: Lint (pre-commit)
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -33,6 +35,7 @@ jobs:
       working-directory: ./apiserver
     name: Build Apiserver and Docker Images
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -109,6 +112,7 @@ jobs:
       working-directory: ./apiserversdk
     name: Build apiserversdk
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -137,6 +141,7 @@ jobs:
       working-directory: ./experimental
     name: Build security proxy Binaries and Docker Images
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
 
       - name: Set up Go
@@ -211,6 +216,7 @@ jobs:
       working-directory: ./ray-operator
     name: Build Operator Binaries and Docker Images
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
 
     - name: Set up Go
@@ -325,6 +331,7 @@ jobs:
       working-directory: ./kubectl-plugin
     name: Build Ray Kubectl plugin
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Stop running CI tests on Draft PRs 
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Refined CI triggers to run only on specific pull-request event types and extended which push event types trigger workflows.
  - Added conditional gating so key verification and build jobs only run on push events or on pull requests that are not drafts.
  - No changes to individual job steps or produced artifacts; changes only affect when jobs execute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->