### PR TITLE
CARRY: (RHOAIENG-32628) - enable more e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
 
             set -euo pipefail
             cd ray-operator
-            go test -timeout 30m -v ./test/e2erayjob -json 2>&1 | tee ./goteste2erayjob.log | gotestfmt
+            go test -timeout 60m -v ./test/e2erayjob -json 2>&1 | tee ./goteste2erayjob.log | gotestfmt
 
         - name: Print KubeRay operator logs
           if: steps.deploy.outcome == 'success'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -58,7 +58,17 @@ jobs:
 
             set -euo pipefail
             cd ray-operator
-            go test -timeout 60m -v ./test/e2e -json 2>&1 -skip TestRayClusterGCSFaultTolerance | tee ./gotest.log | gotestfmt
+            go test -timeout 30m -v ./test/e2e -json 2>&1 | tee ./goteste2e.log | gotestfmt
+
+        - name: Run rayjob e2e tests
+          run: |
+            export KUBERAY_TEST_TIMEOUT_SHORT=3m
+            export KUBERAY_TEST_TIMEOUT_MEDIUM=10m
+            export KUBERAY_TEST_TIMEOUT_LONG=15m
+
+            set -euo pipefail
+            cd ray-operator
+            go test -timeout 30m -v ./test/e2erayjob -json 2>&1 | tee ./goteste2erayjob.log | gotestfmt
 
         - name: Print KubeRay operator logs
           if: steps.deploy.outcome == 'success'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -73,12 +73,13 @@ jobs:
             go test -timeout 60m -v ./test/e2erayjob -json 2>&1 | tee ./goteste2erayjob.log | gotestfmt
 
         - name: Print KubeRay operator logs
-          if: steps.deploy.outcome == 'success'
+          if: always()
           run: |
             echo "Printing KubeRay operator logs"
             kubectl logs -n default --tail -1 -l app.kubernetes.io/name=kuberay-operator app.kubernetes.io/name=kuberay | tee ./kuberay-operator.log
 
         - name: Upload logs
+          if: always()
           uses: actions/upload-artifact@v4
           with:
             name: logs

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -51,6 +51,7 @@ jobs:
             kubectl wait --timeout=90s --for=condition=Available=true deployment -n default kuberay-operator
 
         - name: Run e2e tests
+          if: steps.deploy.outcome == 'success'
           run: |
             export KUBERAY_TEST_TIMEOUT_SHORT=3m
             export KUBERAY_TEST_TIMEOUT_MEDIUM=10m
@@ -58,9 +59,10 @@ jobs:
 
             set -euo pipefail
             cd ray-operator
-            go test -timeout 30m -v ./test/e2e -json 2>&1 | tee ./goteste2e.log | gotestfmt
+            go test -timeout 30m -v ./test/e2e -skip TestRayClusterGCSFaultTolerance -json 2>&1 | tee ./goteste2e.log | gotestfmt
 
         - name: Run rayjob e2e tests
+          if: steps.deploy.outcome == 'success'
           run: |
             export KUBERAY_TEST_TIMEOUT_SHORT=3m
             export KUBERAY_TEST_TIMEOUT_MEDIUM=10m


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Gate end-to-end suites to run only after successful operator deployment.
  * Add a separate rayjob e2e suite alongside the cluster e2e suite.
  * Reduce overall test timeout for the main path to speed feedback; keep per-suite short/medium/long timeouts.
  * Split and rename test logs for clearer diagnostics.
  * Ensure operator logs and log uploads run regardless of prior step outcomes.
  * Preserve exported test timeout variables across steps for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->