### PR TITLE
PATCH: fix build test image

### DIFF
--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -24,16 +24,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Podman
-        uses: redhat-actions/setup-podman@v2
-
       - name: Login to Quay.io
         id: podman-login-quay
-        uses: redhat-actions/podman-login@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_ODH_KUBERAY_TESTS_USERNAME }}
-          password: ${{ secrets.QUAY_ODH_KUBERAY_TESTS_PASSWORD }}
+        run:  podman login --username ${{ secrets.QUAY_ODH_KUBERAY_TESTS_USERNAME }} --password ${{ secrets.QUAY_ODH_KUBERAY_TESTS_PASSWORD }} quay.io
 
       - name: Build test image
         run: make build-test-image

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -26,7 +26,12 @@ jobs:
 
       - name: Login to Quay.io
         id: podman-login-quay
-        run:  podman login --username ${{ secrets.QUAY_ODH_KUBERAY_TESTS_USERNAME }} --password ${{ secrets.QUAY_ODH_KUBERAY_TESTS_PASSWORD }} quay.io
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_ODH_KUBERAY_TESTS_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_ODH_KUBERAY_TESTS_PASSWORD }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$QUAY_PASSWORD" | podman login --username "$QUAY_USERNAME" --password-stdin quay.io
 
       - name: Build test image
         run: make build-test-image


### PR DESCRIPTION
## Why are these changes needed?

PATCH: fix build test image (to use standard shell commands due to failed build

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined container registry authentication in the build pipeline by switching from an external action to a direct CLI login, reducing external dependencies.
  * Preserved image build, push, and post-build logout behavior; overall workflow outcomes remain unchanged.
  * Made login operations more transparent in build logs; relies on container tooling being available in the runner environment.
  * No changes to product features or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->