### PR TITLE
PATCH: bring back e2e tests with workaround for resources

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -50,7 +50,17 @@ jobs:
             make deploy -e IMG="${IMG}"
             kubectl wait --timeout=90s --for=condition=Available=true deployment -n default kuberay-operator
 
+        - name: Update resource requirements for e2e tests
+          if: steps.deploy.outcome == 'success'
+          run: |
+            echo "Updating resource requirements using Go AST manipulation..."
+            cd scripts
+            go build -o update-resources update-resources.go
+            ./update-resources -scenario pr ../ray-operator/test/support/support.go
+            echo "Resource requirements updated successfully for e2e tests."
+
         - name: Run e2e tests
+          if: steps.deploy.outcome == 'success'
           run: |
             export KUBERAY_TEST_TIMEOUT_SHORT=3m
             export KUBERAY_TEST_TIMEOUT_MEDIUM=10m
@@ -58,7 +68,18 @@ jobs:
 
             set -euo pipefail
             cd ray-operator
-            go test -timeout 60m -v ./test/e2e -json 2>&1 -skip TestRayClusterGCSFaultTolerance | tee ./gotest.log | gotestfmt
+            go test -timeout 60m -v ./test/e2e -json 2>&1 | tee ./gotest.log | gotestfmt
+
+        - name: Run e2e rayjob tests
+          if: steps.deploy.outcome == 'success'
+          run: |
+            export KUBERAY_TEST_TIMEOUT_SHORT=3m
+            export KUBERAY_TEST_TIMEOUT_MEDIUM=10m
+            export KUBERAY_TEST_TIMEOUT_LONG=15m
+
+            set -euo pipefail
+            cd ray-operator
+            go test -timeout 60m -v ./test/e2erayjob -json 2>&1 | tee ./gotest.log | gotestfmt
 
         - name: Print KubeRay operator logs
           if: steps.deploy.outcome == 'success'
@@ -67,6 +88,7 @@ jobs:
             kubectl logs -n default --tail -1 -l app.kubernetes.io/name=kuberay-operator app.kubernetes.io/name=kuberay | tee ./kuberay-operator.log
 
         - name: Upload logs
+          if: failure()
           uses: actions/upload-artifact@v4
           with:
             name: logs

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-test-image:
 	# Update resource requirements in support.go using Go AST manipulation
 	@echo "Updating resource requirements using Go AST manipulation..."
 	@cd scripts && go build -o update-resources update-resources.go
-	@scripts/update-resources ray-operator/test/support/support.go
+	@scripts/update-resources -scenario build-image ray-operator/test/support/support.go
 	@echo "Resource requirements updated successfully using Go AST."
 	# Build the Docker image using podman
 	podman build -f ray-operator/images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .


### PR DESCRIPTION
## Why are these changes needed?

PATCH: bring back e2e tests with workaround for resources

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end flow to run specific test suites after successful deployments, split certain suites for clearer coverage, and kept standardized timeouts and formatted output for readability.
  * Operator logs are captured after successful deploys for more reliable diagnostics.

* **Chores**
  * CI now uploads logs only on failure, reducing noise.
  * Introduced selectable resource profiles (scenarios) used by build and test flows to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->