### PR TITLE
PATCH: (RHOAIENG-30970): make the test tier param conform to ods jenkins

### DIFF
--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -8,8 +8,56 @@ set +o allexport
 # Create results directory if it doesn't exist
 mkdir -p results
 
+# Initialize variables
+PARSED_TEST_TAGS=""
+EXTRA_ARGS=()
+
+# Function to show usage
+show_usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Options:"
+    echo "  -testTier=VALUE    Specify test tier (Sanity, Tier1, or Sanity,Tier1)"
+    echo "  -h, -help          Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0 -testTier=Sanity"
+    echo "  $0 -testTier=Tier1"
+    echo "  $0 -testTier=Sanity,Tier1"
+    echo "  $0 -testTier=\"Sanity Tier1\""
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -testTier=*)
+            PARSED_TEST_TAGS="${1#*=}"
+            shift
+            ;;
+        -h|-help|--help)
+            show_usage
+            ;;
+        *)
+            # Collect unknown arguments to pass to gotestsum
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Set TEST_TAGS only from command line arguments
+TEST_TAGS="$PARSED_TEST_TAGS"
+
+# If no TEST_TAGS provided via command line, show usage and exit
+if [[ -z "$TEST_TAGS" ]]; then
+    echo "Info: No test tier specified."
+    echo ""
+    show_usage
+fi
+
 TEST_RUN_REGEX=""
 
+# Handle different combinations of test tags
 if [[ "$TEST_TAGS" == *"Sanity"* && "$TEST_TAGS" == *"Tier1"* ]]; then
     echo "Running Sanity and Tier1 kuberay e2e tests"
     TEST_RUN_REGEX="^(TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$"
@@ -20,9 +68,10 @@ elif [[ "$TEST_TAGS" == *"Tier1"* ]]; then
     echo "Running Tier1 kuberay tests"
     TEST_RUN_REGEX="^(TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$"
 else
-    echo "No valid TEST_TAGS provided (Sanity or Tier1). Exiting."
-    exit 1
+    echo "Info: Invalid test tier '$TEST_TAGS'. Valid options are: Sanity, Tier1, or both (Sanity,Tier1 or 'Sanity Tier1')"
+    echo ""
+    show_usage
 fi
 
 # Run tests with junit XML output
-gotestsum --format testname --junitfile results/xunit_report.xml -- -run "$TEST_RUN_REGEX" ./test/e2erayjob -p 1 -parallel 1 "$@"
+gotestsum --format standard-verbose --junitfile results/xunit_report.xml -- -run "$TEST_RUN_REGEX" ./test/e2erayjob -p 1 -parallel 1 "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PATCH: (RHOAIENG-30970): make the test tier param conform to ods jenkins

## Related issue number

[RHOAIENG-30970](https://issues.redhat.com/browse/RHOAIENG-30970)

## Local run

```
make build-test-image
Building test image: quay.io/opendatahub/kuberay-tests:latest
# Comment out t.Parallel() calls in the test file
# Update resource requirements in support.go using Go AST manipulation
Updating resource requirements using Go AST manipulation...
Applying scenario 'build-image' to ray-operator/test/support/support.go
  Updating "500m": "500m" -> "2000m" (Function: Head, CPU: true, Requests: false)
  Updating "2G": "2G" -> "10G" (Function: Head, CPU: false, Requests: false)
  Updating "300m": "300m" -> "500m" (Function: Head, CPU: true, Requests: true)
  Updating "1G": "1G" -> "6G" (Function: Head, CPU: false, Requests: true)
  Updating "500m": "500m" -> "1000m" (Function: Worker, CPU: true, Requests: false)
  Updating "1G": "1G" -> "3G" (Function: Worker, CPU: false, Requests: false)
  Updating "300m": "300m" -> "500m" (Function: Worker, CPU: true, Requests: true)
Successfully updated resources in ray-operator/test/support/support.go
Resource requirements updated successfully using Go AST.
# Build the Docker image using podman with specified platform
podman build --platform linux/amd64 -f ray-operator/images/tests/Dockerfile -t quay.io/opendatahub/kuberay-tests:latest .
STEP 1/10: FROM golang:1.24
STEP 2/10: ENV KUBECONFIG=/kuberay/tests/.kube/config
--> Using cache 277c74203ca83cbfca1c0bb23d93ad546ed0514ca1d5f6461a95c2f200a24811
--> 277c74203ca8
STEP 3/10: WORKDIR /kuberay/tests
--> Using cache f59bb2c2f78e7d4290dcfb55a33112902cf4a9840d04be079f97b770cd86671f
--> f59bb2c2f78e
STEP 4/10: RUN wget -q https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.18/openshift-client-linux.tar.gz -P oc-client &&     tar -xf oc-client/openshift-client-linux.tar.gz -C oc-client &&     cp oc-client/oc /usr/local/bin &&     rm -rf oc-client/
--> Using cache 37e8a6e0f7fe4292f766499414738329d0bbd62de171133bb976c80a27f793ab
--> 37e8a6e0f7fe
STEP 5/10: COPY ray-operator/go.mod ray-operator/go.sum ./
--> Using cache 8c7e7a657a2b0696a496f9915b33f07bc1089ab28b4be832ee53e3a88f0144bf
--> 8c7e7a657a2b
STEP 6/10: RUN go mod download &&     go install gotest.tools/gotestsum@latest
--> Using cache b7b7908ef1ece30f7191cea3268e08e58e18dfbbf15c7b755c7884795724e0da
--> b7b7908ef1ec
STEP 7/10: COPY ray-operator .
--> a7a59d3e01e0
STEP 8/10: COPY ray-operator/images/tests/.env-odh .env-odh
--> 0161d65f02f2
STEP 9/10: COPY ray-operator/images/tests/run-tests.sh .
--> 0fa4340236d7
STEP 10/10: ENTRYPOINT ["bash", "run-tests.sh"]
COMMIT quay.io/opendatahub/kuberay-tests:latest
--> 7dbc472a5321
Successfully tagged quay.io/opendatahub/kuberay-tests:latest
7dbc472a5321a43651b7adb9c7bec814a9b4d262d1287c105c29b544ab005014
# Confirm that the resources/ limits were updated
=== Contents of support.go (resource values) ===
149:						corev1.ResourceCPU:    resource.MustParse("500m"),
150:						corev1.ResourceMemory: resource.MustParse("6G"),
153:						corev1.ResourceCPU:    resource.MustParse("2000m"),
154:						corev1.ResourceMemory: resource.MustParse("10G"),
166:						corev1.ResourceCPU:    resource.MustParse("500m"),
167:						corev1.ResourceMemory: resource.MustParse("1G"),
170:						corev1.ResourceCPU:    resource.MustParse("1000m"),
171:						corev1.ResourceMemory: resource.MustParse("3G"),
188:						corev1.ResourceCPU:    resource.MustParse("500m"),
=== Contents of rayjob_cluster_selector_test.go (t.Parallel comments) ===
42:		// t.Parallel()
69:		// t.Parallel()
93:		// t.Parallel()
```

```
podman run --rm -it --pull=never \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Tier1
Running Tier1 kuberay tests
=== RUN   TestRayJobLightWeightMode
    rayjob_lightweight_test.go:27: [2025-09-18T08:58:15Z] Created ConfigMap test-ns-7mn4p/jobs successfully
=== RUN   TestRayJobLightWeightMode/Successful_RayJob
    rayjob_lightweight_test.go:56: [2025-09-18T08:58:16Z] Created RayJob test-ns-7mn4p/counter successfully
    rayjob_lightweight_test.go:58: [2025-09-18T08:58:16Z] Waiting for RayJob test-ns-7mn4p/counter to complete
--- PASS: TestRayJobLightWeightMode/Successful_RayJob (21.89s)
=== RUN   TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_lightweight_test.go:90: [2025-09-18T08:58:37Z] Created RayJob test-ns-7mn4p/fail successfully
    rayjob_lightweight_test.go:92: [2025-09-18T08:58:37Z] Waiting for RayJob test-ns-7mn4p/fail to complete
--- PASS: TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished (30.82s)
=== RUN   TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_lightweight_test.go:121: [2025-09-18T08:59:08Z] Created RayJob test-ns-7mn4p/stop successfully
    rayjob_lightweight_test.go:123: [2025-09-18T08:59:08Z] Waiting for RayJob test-ns-7mn4p/stop to be 'Running'
    rayjob_lightweight_test.go:127: [2025-09-18T08:59:35Z] Waiting for RayJob test-ns-7mn4p/stop to be 'Complete'
    rayjob_lightweight_test.go:137: [2025-09-18T09:00:00Z] Deleted RayJob test-ns-7mn4p/stop successfully
--- PASS: TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (51.65s)
    test.go:114: [2025-09-18T09:00:00Z] Retrieving Pod Container test-ns-7mn4p/fail-tdppr-head/ray-head logs
    test.go:102: [2025-09-18T09:00:00Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-18T09:00:00Z] Output directory has been created at: /tmp/TestRayJobLightWeightMode2751183164/001
    test.go:114: [2025-09-18T09:00:00Z] Retrieving Pod Container test-ns-7mn4p/fail-tdppr-head/oauth-proxy logs
    test.go:114: [2025-09-18T09:00:00Z] Retrieving Pod Container test-ns-7mn4p/fail-tdppr-small-group-worker-txvkr/ray-worker logs
    test.go:114: [2025-09-18T09:00:00Z] Retrieving Pod Container test-ns-7mn4p/stop-fhdp4-head/ray-head logs
    test.go:114: [2025-09-18T09:00:00Z] Retrieving Pod Container test-ns-7mn4p/stop-fhdp4-head/oauth-proxy logs
    test.go:114: [2025-09-18T09:00:01Z] Retrieving Pod Container test-ns-7mn4p/stop-fhdp4-small-group-worker-g56rd/ray-worker logs
--- PASS: TestRayJobLightWeightMode (106.44s)
=== RUN   TestRayJobSuspend
    rayjob_suspend_test.go:27: [2025-09-18T09:00:01Z] Created ConfigMap test-ns-8lnj4/jobs successfully
=== RUN   TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it.
    rayjob_suspend_test.go:41: [2025-09-18T09:00:01Z] Created RayJob test-ns-8lnj4/long-running successfully
    rayjob_suspend_test.go:43: [2025-09-18T09:00:01Z] Waiting for RayJob test-ns-8lnj4/long-running to be 'Running'
    rayjob_suspend_test.go:47: [2025-09-18T09:00:23Z] Suspend the RayJob test-ns-8lnj4/long-running
    rayjob_suspend_test.go:52: [2025-09-18T09:00:23Z] Waiting for RayJob test-ns-8lnj4/long-running to be 'Suspended'
    rayjob_suspend_test.go:68: [2025-09-18T09:00:23Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:78: [2025-09-18T09:00:50Z] Deleted RayJob test-ns-8lnj4/long-running successfully
--- PASS: TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it. (48.83s)
=== RUN   TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it.
    rayjob_suspend_test.go:97: [2025-09-18T09:00:50Z] Created RayJob test-ns-8lnj4/counter successfully
    rayjob_suspend_test.go:99: [2025-09-18T09:00:50Z] Waiting for RayJob test-ns-8lnj4/counter to be 'Suspended'
    rayjob_suspend_test.go:103: [2025-09-18T09:00:51Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:108: [2025-09-18T09:00:52Z] Waiting for RayJob test-ns-8lnj4/counter to complete
    rayjob_suspend_test.go:123: [2025-09-18T09:01:32Z] Deleted RayJob test-ns-8lnj4/counter successfully
--- PASS: TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it. (44.67s)
    test.go:102: [2025-09-18T09:01:35Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-18T09:01:35Z] Output directory has been created at: /tmp/TestRayJobSuspend2060252320/001
--- PASS: TestRayJobSuspend (94.29s)
=== RUN   TestRayJob
    rayjob_test.go:29: [2025-09-18T09:01:35Z] Created ConfigMap test-ns-nqqvl/jobs successfully
=== RUN   TestRayJob/Successful_RayJob
    rayjob_test.go:46: [2025-09-18T09:01:36Z] Created RayJob test-ns-nqqvl/counter successfully
    rayjob_test.go:48: [2025-09-18T09:01:36Z] Waiting for RayJob test-ns-nqqvl/counter to complete
    rayjob_test.go:64: [2025-09-18T09:02:22Z] Checking that the RayJob status info has been set correctly.
    rayjob_test.go:81: [2025-09-18T09:02:22Z] Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.
    rayjob_test.go:91: [2025-09-18T09:02:52Z] Deleted RayJob test-ns-nqqvl/counter successfully
--- PASS: TestRayJob/Successful_RayJob (76.68s)
=== RUN   TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_test.go:105: [2025-09-18T09:02:52Z] Created RayJob test-ns-nqqvl/fail successfully
    rayjob_test.go:107: [2025-09-18T09:02:52Z] Waiting for RayJob test-ns-nqqvl/fail to complete
    rayjob_test.go:130: [2025-09-18T09:03:40Z] Deleted RayJob test-ns-nqqvl/fail successfully
--- PASS: TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished (47.83s)
=== RUN   TestRayJob/Failing_submitter_K8s_Job
    rayjob_test.go:158: [2025-09-18T09:03:40Z] Created RayJob test-ns-nqqvl/fail-k8s-job successfully
    rayjob_test.go:160: [2025-09-18T09:03:40Z] Waiting for RayJob test-ns-nqqvl/fail-k8s-job to complete
    rayjob_test.go:183: [2025-09-18T09:04:51Z] Deleted RayJob test-ns-nqqvl/fail-k8s-job successfully
--- PASS: TestRayJob/Failing_submitter_K8s_Job (71.25s)
=== RUN   TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_test.go:197: [2025-09-18T09:04:51Z] Created RayJob test-ns-nqqvl/stop successfully
    rayjob_test.go:199: [2025-09-18T09:04:51Z] Waiting for RayJob test-ns-nqqvl/stop to be 'Running'
    rayjob_test.go:203: [2025-09-18T09:05:18Z] Waiting for RayJob test-ns-nqqvl/stop to be 'Complete'
    rayjob_test.go:213: [2025-09-18T09:05:55Z] Deleted RayJob test-ns-nqqvl/stop successfully
--- PASS: TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (64.08s)
=== RUN   TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string
    rayjob_test.go:225: [2025-09-18T09:05:55Z] Created RayJob test-ns-nqqvl/invalid-yamlstr successfully
--- PASS: TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string (5.15s)
=== RUN   TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds
    rayjob_test.go:244: [2025-09-18T09:06:01Z] Created RayJob test-ns-nqqvl/long-running successfully
    rayjob_test.go:247: [2025-09-18T09:06:01Z] Waiting for RayJob test-ns-nqqvl/long-running to be 'Complete'
--- PASS: TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds (7.26s)
=== RUN   TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally
    rayjob_test.go:270: [2025-09-18T09:06:08Z] Created RayJob test-ns-nqqvl/managed-externally successfully
    rayjob_test.go:296: [2025-09-18T09:06:09Z] Deleted RayJob test-ns-nqqvl/managed-externally successfully
--- PASS: TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally (1.26s)
    test.go:114: [2025-09-18T09:06:09Z] Retrieving Pod Container test-ns-nqqvl/long-running-89jhj-head/ray-head logs
    test.go:102: [2025-09-18T09:06:09Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-18T09:06:09Z] Output directory has been created at: /tmp/TestRayJob708199463/001
    test.go:114: [2025-09-18T09:06:09Z] Retrieving Pod Container test-ns-nqqvl/long-running-89jhj-head/oauth-proxy logs
    test.go:114: [2025-09-18T09:06:09Z] Retrieving Pod Container test-ns-nqqvl/long-running-89jhj-small-group-worker-hwcx7/ray-worker logs
    test.go:114: [2025-09-18T09:06:10Z] Error getting logs from container test-ns-nqqvl/long-running-89jhj-small-group-worker-hwcx7/ray-worker
--- PASS: TestRayJob (274.57s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2erayjob	475.413s

DONE 15 tests in 475.417s
```

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added CLI flags to select test tiers and pass through extra arguments.
  - Expanded help/usage with clearer options and examples.
  - Enhanced test selection to support Sanity, Tier1, or combined runs.
  - Improved handling of invalid or missing input with informative messages.
  - Standardized test execution with verbose output and an xUnit report saved to results/xunit_report.xml.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->