### PR TITLE
RHOAIENG-34798: PATCH: make tests consistently pass irrespictive of env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@ build-test-image:
 	@echo "Updating resource requirements using Go AST manipulation..."
 	@cd scripts && go build -o update-resources update-resources.go
 	@scripts/update-resources -scenario build-image ray-operator/test/support/support.go
+	@scripts/update-resources -scenario build-image ray-operator/test/e2erayjob/rayjob_lightweight_test.go
 	@echo "Resource requirements updated successfully using Go AST."
 	# Build the Docker image using podman
 	podman build -f ray-operator/images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
 	# Confirm that the resources/ limits were updated
 	@echo "=== Contents of support.go (resource values) ==="
 	@grep -n 'resource\.MustParse(' ray-operator/test/support/support.go | grep -E '"(500m|1000m|2000m|1G|3G|6G|10G)"'
+	@echo "=== Contents of rayjob_lightweight_test.go (Ray parameters) ==="
+	@grep -n -E '(num-cpus|num-gpus|WithEntrypointNum)' ray-operator/test/e2erayjob/rayjob_lightweight_test.go
 	@echo "=== Contents of rayjob_cluster_selector_test.go (t.Parallel comments) ==="
 	@grep -n 't\.Parallel()' ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

RHOAIENG-34798: PATCH: make tests consistently pass irrespictive of env

## Related issue number

[RHOAIENG-34798](https://issues.redhat.com/browse/RHOAIENG-34798)

## Verification
```
- build the image
- run the tests against PSI/ ROSA cluster - they should now pass 100% of the time
```

## Checks

```
podman run --rm -it --pull=never \ 
  --platform linux/amd64 \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Sanity,Tier1
Running Sanity and Tier1 kuberay e2e tests
=== RUN   TestRayJobWithClusterSelector
    rayjob_cluster_selector_test.go:27: [2025-09-23T13:32:39Z] Created ConfigMap test-ns-s2q5b/jobs successfully
    rayjob_cluster_selector_test.go:35: [2025-09-23T13:32:39Z] Created RayCluster test-ns-s2q5b/raycluster successfully
    rayjob_cluster_selector_test.go:37: [2025-09-23T13:32:39Z] Waiting for RayCluster test-ns-s2q5b/raycluster to become ready
=== RUN   TestRayJobWithClusterSelector/Successful_RayJob
    rayjob_cluster_selector_test.go:57: [2025-09-23T13:33:05Z] Created RayJob test-ns-s2q5b/counter successfully
    rayjob_cluster_selector_test.go:59: [2025-09-23T13:33:05Z] Waiting for RayJob test-ns-s2q5b/counter to complete
--- PASS: TestRayJobWithClusterSelector/Successful_RayJob (16.01s)
=== RUN   TestRayJobWithClusterSelector/Failing_RayJob
    rayjob_cluster_selector_test.go:81: [2025-09-23T13:33:21Z] Created RayJob test-ns-s2q5b/fail successfully
    rayjob_cluster_selector_test.go:83: [2025-09-23T13:33:21Z] Waiting for RayJob test-ns-s2q5b/fail to complete
--- PASS: TestRayJobWithClusterSelector/Failing_RayJob (12.66s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally
    rayjob_cluster_selector_test.go:109: [2025-09-23T13:33:34Z] Created RayJob test-ns-s2q5b/managed-externally successfully
--- PASS: TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally (3.14s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value
--- PASS: TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value (0.12s)
    test.go:114: [2025-09-23T13:33:37Z] Retrieving Pod Container test-ns-s2q5b/counter-x4nqg/ray-job-submitter logs
    test.go:102: [2025-09-23T13:33:37Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-23T13:33:37Z] Output directory has been created at: /tmp/TestRayJobWithClusterSelector322656066/001
    test.go:114: [2025-09-23T13:33:37Z] Retrieving Pod Container test-ns-s2q5b/fail-ngdgl/ray-job-submitter logs
    test.go:114: [2025-09-23T13:33:38Z] Retrieving Pod Container test-ns-s2q5b/raycluster-head/ray-head logs
    test.go:114: [2025-09-23T13:33:38Z] Retrieving Pod Container test-ns-s2q5b/raycluster-head/oauth-proxy logs
    test.go:114: [2025-09-23T13:33:38Z] Retrieving Pod Container test-ns-s2q5b/raycluster-small-group-worker-8ltg2/ray-worker logs
--- PASS: TestRayJobWithClusterSelector (59.99s)
=== RUN   TestRayJobLightWeightMode
    rayjob_lightweight_test.go:27: [2025-09-23T13:33:39Z] Created ConfigMap test-ns-hfrb2/jobs successfully
=== RUN   TestRayJobLightWeightMode/Successful_RayJob
    rayjob_lightweight_test.go:56: [2025-09-23T13:33:39Z] Created RayJob test-ns-hfrb2/counter successfully
    rayjob_lightweight_test.go:58: [2025-09-23T13:33:39Z] Waiting for RayJob test-ns-hfrb2/counter to complete
--- PASS: TestRayJobLightWeightMode/Successful_RayJob (25.43s)
=== RUN   TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_lightweight_test.go:90: [2025-09-23T13:34:04Z] Created RayJob test-ns-hfrb2/fail successfully
    rayjob_lightweight_test.go:92: [2025-09-23T13:34:04Z] Waiting for RayJob test-ns-hfrb2/fail to complete
--- PASS: TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished (31.13s)
=== RUN   TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_lightweight_test.go:121: [2025-09-23T13:34:35Z] Created RayJob test-ns-hfrb2/stop successfully
    rayjob_lightweight_test.go:123: [2025-09-23T13:34:35Z] Waiting for RayJob test-ns-hfrb2/stop to be 'Running'
    rayjob_lightweight_test.go:127: [2025-09-23T13:35:02Z] Waiting for RayJob test-ns-hfrb2/stop to be 'Complete'
    rayjob_lightweight_test.go:137: [2025-09-23T13:35:27Z] Deleted RayJob test-ns-hfrb2/stop successfully
--- PASS: TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (52.31s)
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/fail-pk8m4-head/ray-head logs
    test.go:102: [2025-09-23T13:35:28Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-23T13:35:28Z] Output directory has been created at: /tmp/TestRayJobLightWeightMode1941605387/001
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/fail-pk8m4-head/oauth-proxy logs
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/fail-pk8m4-small-group-worker-lvs2d/ray-worker logs
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/stop-g6l75-head/ray-head logs
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/stop-g6l75-head/oauth-proxy logs
    test.go:114: [2025-09-23T13:35:28Z] Retrieving Pod Container test-ns-hfrb2/stop-g6l75-small-group-worker-gl7jz/ray-worker logs
--- PASS: TestRayJobLightWeightMode (110.52s)
=== RUN   TestRayJobSuspend
    rayjob_suspend_test.go:27: [2025-09-23T13:35:29Z] Created ConfigMap test-ns-tff9k/jobs successfully
=== RUN   TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it.
    rayjob_suspend_test.go:41: [2025-09-23T13:35:29Z] Created RayJob test-ns-tff9k/long-running successfully
    rayjob_suspend_test.go:43: [2025-09-23T13:35:29Z] Waiting for RayJob test-ns-tff9k/long-running to be 'Running'
    rayjob_suspend_test.go:47: [2025-09-23T13:35:55Z] Suspend the RayJob test-ns-tff9k/long-running
    rayjob_suspend_test.go:52: [2025-09-23T13:35:55Z] Waiting for RayJob test-ns-tff9k/long-running to be 'Suspended'
    rayjob_suspend_test.go:68: [2025-09-23T13:35:56Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:78: [2025-09-23T13:36:23Z] Deleted RayJob test-ns-tff9k/long-running successfully
--- PASS: TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it. (53.92s)
=== RUN   TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it.
    rayjob_suspend_test.go:97: [2025-09-23T13:36:23Z] Created RayJob test-ns-tff9k/counter successfully
    rayjob_suspend_test.go:99: [2025-09-23T13:36:23Z] Waiting for RayJob test-ns-tff9k/counter to be 'Suspended'
    rayjob_suspend_test.go:103: [2025-09-23T13:36:23Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:108: [2025-09-23T13:36:24Z] Waiting for RayJob test-ns-tff9k/counter to complete
    rayjob_suspend_test.go:123: [2025-09-23T13:37:10Z] Deleted RayJob test-ns-tff9k/counter successfully
--- PASS: TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it. (51.16s)
    test.go:102: [2025-09-23T13:37:15Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-23T13:37:15Z] Output directory has been created at: /tmp/TestRayJobSuspend3997556116/001
--- PASS: TestRayJobSuspend (105.91s)
=== RUN   TestRayJob
    rayjob_test.go:29: [2025-09-23T13:37:15Z] Created ConfigMap test-ns-84mgp/jobs successfully
=== RUN   TestRayJob/Successful_RayJob
    rayjob_test.go:46: [2025-09-23T13:37:15Z] Created RayJob test-ns-84mgp/counter successfully
    rayjob_test.go:48: [2025-09-23T13:37:15Z] Waiting for RayJob test-ns-84mgp/counter to complete
    rayjob_test.go:64: [2025-09-23T13:38:00Z] Checking that the RayJob status info has been set correctly.
    rayjob_test.go:81: [2025-09-23T13:38:01Z] Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.
    rayjob_test.go:91: [2025-09-23T13:38:31Z] Deleted RayJob test-ns-84mgp/counter successfully
--- PASS: TestRayJob/Successful_RayJob (76.03s)
=== RUN   TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_test.go:105: [2025-09-23T13:38:31Z] Created RayJob test-ns-84mgp/fail successfully
    rayjob_test.go:107: [2025-09-23T13:38:31Z] Waiting for RayJob test-ns-84mgp/fail to complete
    rayjob_test.go:130: [2025-09-23T13:39:18Z] Deleted RayJob test-ns-84mgp/fail successfully
--- PASS: TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished (48.26s)
=== RUN   TestRayJob/Failing_submitter_K8s_Job
    rayjob_test.go:158: [2025-09-23T13:39:19Z] Created RayJob test-ns-84mgp/fail-k8s-job successfully
    rayjob_test.go:160: [2025-09-23T13:39:19Z] Waiting for RayJob test-ns-84mgp/fail-k8s-job to complete
    rayjob_test.go:183: [2025-09-23T13:40:30Z] Deleted RayJob test-ns-84mgp/fail-k8s-job successfully
--- PASS: TestRayJob/Failing_submitter_K8s_Job (71.01s)
=== RUN   TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_test.go:197: [2025-09-23T13:40:30Z] Created RayJob test-ns-84mgp/stop successfully
    rayjob_test.go:199: [2025-09-23T13:40:30Z] Waiting for RayJob test-ns-84mgp/stop to be 'Running'
    rayjob_test.go:203: [2025-09-23T13:40:57Z] Waiting for RayJob test-ns-84mgp/stop to be 'Complete'
    rayjob_test.go:213: [2025-09-23T13:41:34Z] Deleted RayJob test-ns-84mgp/stop successfully
--- PASS: TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (63.66s)
=== RUN   TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string
    rayjob_test.go:225: [2025-09-23T13:41:34Z] Created RayJob test-ns-84mgp/invalid-yamlstr successfully
--- PASS: TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string (5.15s)
=== RUN   TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds
    rayjob_test.go:244: [2025-09-23T13:41:39Z] Created RayJob test-ns-84mgp/long-running successfully
    rayjob_test.go:247: [2025-09-23T13:41:39Z] Waiting for RayJob test-ns-84mgp/long-running to be 'Complete'
--- PASS: TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds (7.29s)
=== RUN   TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally
    rayjob_test.go:270: [2025-09-23T13:41:47Z] Created RayJob test-ns-84mgp/managed-externally successfully
    rayjob_test.go:296: [2025-09-23T13:41:47Z] Deleted RayJob test-ns-84mgp/managed-externally successfully
--- PASS: TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally (1.08s)
    test.go:114: [2025-09-23T13:41:48Z] Retrieving Pod Container test-ns-84mgp/long-running-nj2rw-head/ray-head logs
    test.go:102: [2025-09-23T13:41:48Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-23T13:41:48Z] Output directory has been created at: /tmp/TestRayJob3934483359/001
    test.go:114: [2025-09-23T13:41:48Z] Retrieving Pod Container test-ns-84mgp/long-running-nj2rw-head/oauth-proxy logs
    test.go:114: [2025-09-23T13:41:48Z] Retrieving Pod Container test-ns-84mgp/long-running-nj2rw-small-group-worker-bvhkv/ray-worker logs
    test.go:114: [2025-09-23T13:41:48Z] Error getting logs from container test-ns-84mgp/long-running-nj2rw-small-group-worker-bvhkv/ray-worker
--- PASS: TestRayJob (274.08s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2erayjob	550.616s

DONE 20 tests in 550.619s
```

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced resource updater to support Ray start and entrypoint CPU/GPU parameter overrides.

- Tests
  - Added build-time validation for lightweight Ray job parameters to ensure expected values.
  - Introduced confirmations to surface which updates were applied during test updates.

- Chores
  - Improved update logic to skip no-op changes when values are empty or unchanged.
  - Extended automation to update and verify an additional Ray-related test scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->