### PR TITLE
CARRY [NO JIRA]: add/increase test timeout to 2.24 branch

### DIFF
--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -74,4 +74,4 @@ else
 fi
 
 # Run tests with junit XML output
-gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -run "$TEST_RUN_REGEX" ./test/e2erayjob -p 1 -parallel 1 "${EXTRA_ARGS[@]}"
+gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout 30m -run "$TEST_RUN_REGEX" ./test/e2erayjob -p 1 -parallel 1 "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

To increase timeout from default (when unspecified) 10m to 30m to allow the tests enough time to pass

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(
