### PR TITLE
Merge release-1.4 to new dev branch

### DIFF
--- a/.buildkite/test-e2e.yml
+++ b/.buildkite/test-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test E2E (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -20,7 +20,7 @@
 
 - label: 'Test E2E rayservice (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -40,7 +40,7 @@
 
 - label: 'Test Autoscaler E2E Part 1 (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -60,7 +60,7 @@
 
 - label: 'Test Autoscaler E2E Part 2 (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -80,7 +80,7 @@
 
 - label: 'Test E2E Operator Version Upgrade (v1.3.0)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -99,7 +99,7 @@
 
 - label: 'Test Apiserver E2E (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-kubectl-plugin-e2e.yml
+++ b/.buildkite/test-kubectl-plugin-e2e.yml
@@ -1,6 +1,6 @@
 - label: 'Test E2E (kubectl-plugin)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.buildkite/test-sample-yamls.yml
+++ b/.buildkite/test-sample-yamls.yml
@@ -1,6 +1,6 @@
 - label: 'Test Sample YAMLs (nightly operator)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml
@@ -21,7 +21,7 @@
 
 - label: 'Test Sample YAMLs (latest release)'
   instance_size: large
-  image: golang:1.24
+  image: golang:1.24-bookworm
   commands:
     - source .buildkite/setup-env.sh
     - kind create cluster --wait 900s --config ./ci/kind-config-buildkite.yml

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,25 +10,25 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_amd64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_darwin_arm64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_amd64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+      {{addURIAndSha "https://github.com/ray-project/kuberay/releases/download/{{ .TagName }}/kubectl-ray_{{ .TagName }}_linux_arm64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-ray
   shortDescription: Ray kubectl plugin
   description: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: _generated.go$|\.svg$|^third_party/|^proto/swagger/|^apiserver/pkg/swagger/datafile.go$|^docs/reference/api.md$|^config/grafana/
 
 default_language_version:
-  golang: 1.24.2
+  golang: 1.24.0
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the backend service
-FROM golang:1.24.2-bullseye AS builder
+FROM golang:1.24.0-bullseye AS builder
 
 WORKDIR /workspace
 

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,5 +1,5 @@
 # Build security proxy
-FROM golang:1.24.2-bullseye AS builder
+FROM golang:1.24.0-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/ray-project/kuberay/ray-operator v1.4.1
+	github.com/ray-project/kuberay/ray-operator v1.4.2
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay
 
-go 1.24.2
+go 1.24.0
 
 require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/ray-project/kuberay/ray-operator v1.4.0
+	github.com/ray-project/kuberay/ray-operator v1.4.1
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1

--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2

--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -8,7 +8,7 @@ name: kuberay-apiserver
 
 image:
   repository: quay.io/kuberay/apiserver
-  tag: v1.4.0
+  tag: v1.4.1
   pullPolicy: IfNotPresent
 
 # Uncomment allowOrigin to enable CORS

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -8,7 +8,7 @@ name: kuberay-apiserver
 
 image:
   repository: quay.io/kuberay/apiserver
-  tag: v1.4.1
+  tag: v1.4.2
   pullPolicy: IfNotPresent
 
 # Uncomment allowOrigin to enable CORS

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: kuberay-operator
 
 description: A Helm chart for deploying the Kuberay operator on Kubernetes.
 
-version: 1.4.1
+version: 1.4.2
 
 type: application
 

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: kuberay-operator
 
 description: A Helm chart for deploying the Kuberay operator on Kubernetes.
 
-version: 1.4.0
+version: 1.4.1
 
 type: application
 

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,6 +1,6 @@
 # kuberay-operator
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the Kuberay operator on Kubernetes.
 
@@ -29,8 +29,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.1.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1
+  # Install both CRDs and KubeRay operator v1.4.2.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -58,10 +58,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.1&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.2&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2 --skip-crds
   ```
 
 ## List the chart
@@ -71,7 +71,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.1
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.2
 ```
 
 ## Uninstall the Chart
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.1
+    targetRevision: v1.4.2
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.1
+    targetRevision: v1.4.2
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true
@@ -148,7 +148,7 @@ spec:
 | fullnameOverride | string | `"kuberay-operator"` | String to fully override release name. |
 | componentOverride | string | `"kuberay-operator"` | String to override component name. |
 | image.repository | string | `"quay.io/kuberay/operator"` | Image repository. |
-| image.tag | string | `"v1.4.1"` | Image tag. |
+| image.tag | string | `"v1.4.2"` | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | labels | object | `{}` | Extra labels. |
 | annotations | object | `{}` | Extra annotations. |

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,6 +1,6 @@
 # kuberay-operator
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the Kuberay operator on Kubernetes.
 
@@ -29,8 +29,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.0
+  # Install both CRDs and KubeRay operator v1.4.1.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -58,10 +58,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.1&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1 --skip-crds
   ```
 
 ## List the chart
@@ -71,7 +71,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.0
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.1
 ```
 
 ## Uninstall the Chart
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.0
+    targetRevision: v1.4.1
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.0
+    targetRevision: v1.4.1
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true
@@ -148,7 +148,7 @@ spec:
 | fullnameOverride | string | `"kuberay-operator"` | String to fully override release name. |
 | componentOverride | string | `"kuberay-operator"` | String to override component name. |
 | image.repository | string | `"quay.io/kuberay/operator"` | Image repository. |
-| image.tag | string | `"v1.4.0"` | Image tag. |
+| image.tag | string | `"v1.4.1"` | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | labels | object | `{}` | Extra labels. |
 | annotations | object | `{}` | Extra annotations. |

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -31,8 +31,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.0
+  # Install both CRDs and KubeRay operator v1.4.1.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -60,10 +60,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.1&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1 --skip-crds
   ```
 
 ## List the chart
@@ -73,7 +73,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.0
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.1
 ```
 
 ## Uninstall the Chart
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.0
+    targetRevision: v1.4.1
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.0
+    targetRevision: v1.4.1
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -31,8 +31,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.1.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1
+  # Install both CRDs and KubeRay operator v1.4.2.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -60,10 +60,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.1&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.2&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.1 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2 --skip-crds
   ```
 
 ## List the chart
@@ -73,7 +73,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.1
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.2
 ```
 
 ## Uninstall the Chart
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.1
+    targetRevision: v1.4.2
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.1
+    targetRevision: v1.4.2
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: quay.io/kuberay/operator
 
   # -- Image tag.
-  tag: v1.4.0
+  tag: v1.4.1
 
   # -- Image pull policy.
   pullPolicy: IfNotPresent

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -16,7 +16,7 @@ image:
   repository: quay.io/kuberay/operator
 
   # -- Image tag.
-  tag: v1.4.1
+  tag: v1.4.2
 
   # -- Image pull policy.
   pullPolicy: IfNotPresent

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 1.4.0
+version: 1.4.1
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 1.4.1
+version: 1.4.2
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_log_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 	It("succeed in retrieving all ray cluster logs", func() {
 		expectedDirPath := "./raycluster-kuberay"
-		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
+		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
 
 		cmd := exec.Command("kubectl", "ray", "log", "--namespace", namespace, "raycluster-kuberay", "--node-type", "all")
 		output, err := cmd.CombinedOutput()
@@ -84,7 +84,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 	It("succeed in retrieving ray cluster head logs", func() {
 		expectedDirPath := "./raycluster-kuberay"
-		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only head node logs\.\nDownloading log for Ray Node raycluster-kuberay-head`
+		expectedOutputStringFormat := `No output directory specified, creating dir under current directory using resource name\.\nCommand set to retrieve only head node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+`
 
 		cmd := exec.Command("kubectl", "ray", "log", "--namespace", namespace, "raycluster-kuberay", "--node-type", "head")
 		output, err := cmd.CombinedOutput()
@@ -191,7 +191,7 @@ var _ = Describe("Calling ray plugin `log` command on Ray Cluster", func() {
 
 	It("succeed in retrieving ray cluster logs within designated directory", func() {
 		expectedDirPath := "./temporary-directory"
-		expectedOutputStringFormat := `Command set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
+		expectedOutputStringFormat := `Command set to retrieve both head and worker node logs\.\nDownloading log for Ray Node raycluster-kuberay-head-\w+\nDownloading log for Ray Node raycluster-kuberay-workergroup-worker-\w+`
 
 		err := os.MkdirAll(expectedDirPath, 0o755)
 		Expect(err).NotTo(HaveOccurred())

--- a/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
+++ b/kubectl-plugin/test/e2e/kubectl_ray_session_test.go
@@ -90,33 +90,33 @@ var _ = Describe("Calling ray plugin `session` command", Ordered, func() {
 		}, 3*time.Second, 500*time.Millisecond).ShouldNot(HaveOccurred())
 
 		// Get the current head pod name
-		cmd := exec.Command("kubectl", "get", "--namespace", namespace, "pod/raycluster-kuberay-head", "-o", "jsonpath={.metadata.uid}")
+		cmd := exec.Command("kubectl", "get", "--namespace", namespace, "raycluster/raycluster-kuberay", "-o", "jsonpath={.status.head.podName}")
 		output, err := cmd.CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
-		oldPodUID := string(output)
-		var newPodUID string
+		oldPodName := string(output)
+		var newPodName string
 
 		// Delete the pod
-		cmd = exec.Command("kubectl", "delete", "--namespace", namespace, "pod/raycluster-kuberay-head")
+		cmd = exec.Command("kubectl", "delete", "--namespace", namespace, "pod", oldPodName)
 		err = cmd.Run()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Wait for the new pod to be created
 		Eventually(func() error {
-			cmd := exec.Command("kubectl", "get", "--namespace", namespace, "pod/raycluster-kuberay-head", "-o", "jsonpath={.metadata.uid}")
+			cmd := exec.Command("kubectl", "get", "--namespace", namespace, "raycluster/raycluster-kuberay", "-o", "jsonpath={.status.head.podName}")
 			output, err := cmd.CombinedOutput()
-			newPodUID = string(output)
+			newPodName = string(output)
 			if err != nil {
 				return err
 			}
-			if newPodUID == oldPodUID {
-				return fmt.Errorf("head pod has not changed (UID still %s)", oldPodUID)
+			if newPodName == oldPodName {
+				return fmt.Errorf("head pod has not changed (Name still %s)", oldPodName)
 			}
 			return nil
 		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 		// Wait for the new pod to be ready
-		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod/raycluster-kuberay-head", "--for=condition=Ready", "--timeout=120s")
+		cmd = exec.Command("kubectl", "wait", "--namespace", namespace, "pod", newPodName, "--for=condition=Ready", "--timeout=120s")
 		err = cmd.Run()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -1,5 +1,5 @@
 # Generate client code (go & json) from API protocol buffers
-FROM golang:1.24.2-bullseye AS generator
+FROM golang:1.24.0-bullseye AS generator
 
 ENV PROTOC_VERSION 3.17.3
 ENV GOLANG_PROTOBUF_VERSION v1.5.2

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -24,9 +24,9 @@ For local development, we recommend using [Kind](https://kind.sigs.k8s.io/) to c
 Currently, KubeRay uses go v1.24 for development.
 
 ```bash
-go install golang.org/dl/go1.24.2@latest
-go1.24.2 download
-export GOROOT=$(go1.24.2 env GOROOT)
+go install golang.org/dl/go1.24.0@latest
+go1.24.0 download
+export GOROOT=$(go1.24.0 env GOROOT)
 export PATH="$GOROOT/bin:$PATH"
 ```
 

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.2-bullseye AS builder
+FROM golang:1.24.0-bullseye AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/ray-operator/config/default-with-webhooks/kustomization.yaml
+++ b/ray-operator/config/default-with-webhooks/kustomization.yaml
@@ -17,7 +17,7 @@ namespace: ray-system
 images:
 - name: kuberay/operator
   newName: quay.io/kuberay/operator
-  newTag: v1.4.0
+  newTag: v1.4.1
 
 
 replacements:

--- a/ray-operator/config/default-with-webhooks/kustomization.yaml
+++ b/ray-operator/config/default-with-webhooks/kustomization.yaml
@@ -17,7 +17,7 @@ namespace: ray-system
 images:
 - name: kuberay/operator
   newName: quay.io/kuberay/operator
-  newTag: v1.4.1
+  newTag: v1.4.2
 
 
 replacements:

--- a/ray-operator/config/default/kustomization.yaml
+++ b/ray-operator/config/default/kustomization.yaml
@@ -18,7 +18,7 @@ namespace: default
 images:
 - name: kuberay/operator
   newName: quay.io/kuberay/operator
-  newTag: v1.4.0
+  newTag: v1.4.1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/ray-operator/config/default/kustomization.yaml
+++ b/ray-operator/config/default/kustomization.yaml
@@ -18,7 +18,7 @@ namespace: default
 images:
 - name: kuberay/operator
   newName: quay.io/kuberay/operator
-  newTag: v1.4.1
+  newTag: v1.4.2
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/ray-operator/controllers/ray/common/pod.go
+++ b/ray-operator/controllers/ray/common/pod.go
@@ -164,7 +164,7 @@ func DefaultHeadPodTemplate(ctx context.Context, instance rayv1.RayCluster, head
 	// headPort is passed into setMissingRayStartParams but unused there for the head pod.
 	// To mitigate this awkwardness and reduce code redundancy, unify head and worker pod configuration logic.
 	podTemplate := headSpec.Template
-	podTemplate.Name = podName
+	podTemplate.GenerateName = podName
 	// Pods created by RayCluster should be restricted to the namespace of the RayCluster.
 	// This ensures privilege of KubeRay users are contained within the namespace of the RayCluster.
 	podTemplate.ObjectMeta.Namespace = instance.Namespace

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -689,7 +689,6 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 			return errstd.Join(utils.ErrFailedCreateHeadPod, err)
 		}
 	} else if len(headPods.Items) > 1 { // This should never happen. This protects against the case that users manually create headpod.
-		correctHeadPodName := instance.Name + "-head"
 		headPodNames := make([]string, len(headPods.Items))
 		for i, pod := range headPods.Items {
 			headPodNames[i] = pod.Name
@@ -697,9 +696,8 @@ func (r *RayClusterReconciler) reconcilePods(ctx context.Context, instance *rayv
 
 		logger.Info("Multiple head pods found, it should only exist one head pod. Please delete extra head pods.",
 			"found pods", headPodNames,
-			"should only leave", correctHeadPodName,
 		)
-		return fmt.Errorf("%d head pods found %v. Please delete extra head pods and leave only the head pod with name %s", len(headPods.Items), headPodNames, correctHeadPodName)
+		return fmt.Errorf("%d head pods found %v. Please delete extra head pods", len(headPods.Items), headPodNames)
 	}
 
 	// Reconcile worker pods now
@@ -1038,7 +1036,7 @@ func (r *RayClusterReconciler) createWorkerPod(ctx context.Context, instance ray
 // Build head instance pod(s).
 func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.RayCluster) corev1.Pod {
 	logger := ctrl.LoggerFrom(ctx)
-	podName := utils.PodName(instance.Name, rayv1.HeadNode, false)
+	podName := utils.PodName(instance.Name, rayv1.HeadNode, true)
 	fqdnRayIP := utils.GenerateFQDNServiceName(ctx, instance, instance.Namespace) // Fully Qualified Domain Name
 
 	// The Ray head port used by workers to connect to the cluster (GCS server port for Ray >= 1.11.0, Redis port for older Ray.)

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -207,7 +207,7 @@ const (
 	// The version is included in the RAY_USAGE_STATS_EXTRA_TAGS environment variable
 	// as well as the user-agent. This constant is updated before release.
 	// TODO: Update KUBERAY_VERSION to be a build-time variable.
-	KUBERAY_VERSION = "v1.4.1"
+	KUBERAY_VERSION = "v1.4.2"
 
 	// KubeRayController represents the value of the default job controller
 	KubeRayController = "ray.io/kuberay-operator"

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -207,7 +207,7 @@ const (
 	// The version is included in the RAY_USAGE_STATS_EXTRA_TAGS environment variable
 	// as well as the user-agent. This constant is updated before release.
 	// TODO: Update KUBERAY_VERSION to be a build-time variable.
-	KUBERAY_VERSION = "v1.4.0"
+	KUBERAY_VERSION = "v1.4.1"
 
 	// KubeRayController represents the value of the default job controller
 	KubeRayController = "ray.io/kuberay-operator"

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -115,7 +115,7 @@ func TestPodName(t *testing.T) {
 			name:     "short cluster name, head pod",
 			prefix:   "ray-cluster-01",
 			nodeType: rayv1.HeadNode,
-			expected: "ray-cluster-01-head",
+			expected: "ray-cluster-01-head-",
 		},
 		{
 			name:     "short cluster name, worker pod",
@@ -127,7 +127,7 @@ func TestPodName(t *testing.T) {
 			name:     "long cluster name, head pod",
 			prefix:   "ray-cluster-0000000000000000000000011111111122222233333333333333",
 			nodeType: rayv1.HeadNode,
-			expected: "ray-cluster-00000000000000000000000111111111222222-head",
+			expected: "ray-cluster-00000000000000000000000111111111222222-head-",
 		},
 		{
 			name:     "long cluster name, worker pod",
@@ -139,8 +139,7 @@ func TestPodName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			isPodNameGenerated := test.nodeType == rayv1.WorkerNode // HeadPod name is now fixed
-			str := PodName(test.prefix, test.nodeType, isPodNameGenerated)
+			str := PodName(test.prefix, test.nodeType, true)
 			if str != test.expected {
 				t.Logf("expected: %q", test.expected)
 				t.Logf("actual: %q", str)

--- a/ray-operator/go.mod
+++ b/ray-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/ray-project/kuberay/ray-operator
 
-go 1.24.2
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped KubeRay operator, API server, and Helm chart versions/tags to v1.4.2.
  - Aligned Go toolchain and base images across builds.
- Refactor
  - Head pod now uses generated names (may include a trailing dash).
  - Simplified error message when multiple head pods are detected.
- Documentation
  - Updated version references and install instructions to v1.4.2.
- Tests
  - Updated kubectl plugin E2E expectations (added download log line; head pod identified by name).
- Style
  - Improved krew manifest formatting (indented URLs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->