### PR TITLE
PATCH [NO JIRA]: reenable openshift e2e tests setup

### DIFF
--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -1,6 +1,9 @@
 name: Build and Push Test Image
 
 on:
+  push:
+    branches:
+      - dev
   workflow_dispatch:
     inputs:
       E2E_TEST_IMAGE_VERSION:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -56,7 +56,7 @@ jobs:
             echo "Updating resource requirements using Go AST manipulation..."
             cd scripts
             go build -o update-resources update-resources.go
-            ./update-resources -scenario pr ../ray-operator/test/support/support.go
+            ./update-resources -scenario pr ../ray-operator/test/e2e/support.go
             echo "Resource requirements updated successfully for e2e tests."
 
         - name: Run e2e tests

--- a/.github/workflows/e2e-upgrade-dispatch-to-bigger-runner.yml
+++ b/.github/workflows/e2e-upgrade-dispatch-to-bigger-runner.yml
@@ -1,9 +1,12 @@
 name: Dispatch
 on:
+  push:
+    branches:
+    - dev
   workflow_dispatch:
 
 jobs:
-  dispatch:
+  run-e2e-upgrade-on-bigger-runner:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -8,25 +8,25 @@ build-test-image:
 	@echo "Building test image: $(E2E_TEST_IMAGE)"
 	# Comment out t.Parallel() calls in the test file
 	@if [ "$$(uname)" = "Darwin" ]; then \
-		sed -i '' 's/t\.Parallel()/\/\/ t.Parallel()/g' ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go; \
+		sed -i '' 's/t\.Parallel()/\/\/ t.Parallel()/g' ray-operator/test/e2e/rayjob_cluster_selector_test.go; \
 	else \
-		sed -i 's/t\.Parallel()/\/\/ t.Parallel()/g' ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go; \
+		sed -i 's/t\.Parallel()/\/\/ t.Parallel()/g' ray-operator/test/e2e/rayjob_cluster_selector_test.go; \
 	fi
 	# Update resource requirements in support.go using Go AST manipulation
 	@echo "Updating resource requirements using Go AST manipulation..."
 	@cd scripts && go build -o update-resources update-resources.go
-	@scripts/update-resources -scenario build-image ray-operator/test/support/support.go
-	@scripts/update-resources -scenario build-image ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+	@scripts/update-resources -scenario build-image ray-operator/test/e2e/support.go
+	@scripts/update-resources -scenario build-image ray-operator/test/e2e/rayjob_lightweight_test.go
 	@echo "Resource requirements updated successfully using Go AST."
 	# Build the Docker image using podman
 	podman build -f ray-operator/images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
 	# Confirm that the resources/ limits were updated
 	@echo "=== Contents of support.go (resource values) ==="
-	@grep -n 'resource\.MustParse(' ray-operator/test/support/support.go | grep -E '"(500m|1000m|2000m|1G|3G|6G|10G)"'
+	@grep -n 'resource\.MustParse(' ray-operator/test/e2e/support.go | grep -E '"(500m|1000m|2000m|1G|3G|6G|10G)"'
 	@echo "=== Contents of rayjob_lightweight_test.go (Ray parameters) ==="
-	@grep -n -E '(num-cpus|num-gpus|WithEntrypointNum)' ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+	@grep -n -E '(num-cpus|num-gpus|WithEntrypointNum)' ray-operator/test/e2e/rayjob_lightweight_test.go
 	@echo "=== Contents of rayjob_cluster_selector_test.go (t.Parallel comments) ==="
-	@grep -n 't\.Parallel()' ray-operator/test/e2erayjob/rayjob_cluster_selector_test.go
+	@grep -n 't\.Parallel()' ray-operator/test/e2e/rayjob_cluster_selector_test.go
 
 # Push the test image
 .PHONY: push-test-image

--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -74,4 +74,4 @@ else
 fi
 
 # Run tests with junit XML output
-gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout 30m -run "$TEST_RUN_REGEX" ./test/e2erayjob -p 1 -parallel 1 "${EXTRA_ARGS[@]}"
+gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout 30m -run "$TEST_RUN_REGEX" ./test/e2e -p 1 -parallel 1 "${EXTRA_ARGS[@]}"

--- a/scripts/update-resources.go
+++ b/scripts/update-resources.go
@@ -156,12 +156,13 @@ func updateResourcesInFile(filePath string, spec ResourceSpec) error {
 func processFunctionDecl(funcDecl *ast.FuncDecl, spec ResourceSpec) {
 	functionName := funcDecl.Name.Name
 
-	// Only process HeadPodTemplate and WorkerPodTemplate functions
-	if !strings.Contains(functionName, "HeadPodTemplate") && !strings.Contains(functionName, "WorkerPodTemplate") {
+	// Only process HeadPodTemplate and WorkerPodTemplate functions (case-insensitive)
+	lowerFunctionName := strings.ToLower(functionName)
+	if !strings.Contains(lowerFunctionName, "headpodtemplate") && !strings.Contains(lowerFunctionName, "workerpodtemplate") {
 		return
 	}
 
-	isHeadFunction := strings.Contains(functionName, "HeadPodTemplate")
+	isHeadFunction := strings.Contains(lowerFunctionName, "headpodtemplate")
 
 	// Track the order of resource.MustParse calls within WithRequests and WithLimits
 	ast.Inspect(funcDecl, func(n ast.Node) bool {
@@ -300,13 +301,14 @@ func printTestFileConfirmation(filePath string) {
 		inWorkerFunction := false
 
 		for i, line := range lines {
-			if strings.Contains(line, "func HeadPodTemplateApplyConfiguration") {
+			lowerLine := strings.ToLower(line)
+			if strings.Contains(lowerLine, "func headpodtemplateapplyconfiguration") {
 				inHeadFunction = true
 				inWorkerFunction = false
-			} else if strings.Contains(line, "func WorkerPodTemplateApplyConfiguration") {
+			} else if strings.Contains(lowerLine, "func workerpodtemplateapplyconfiguration") {
 				inHeadFunction = false
 				inWorkerFunction = true
-			} else if strings.Contains(line, "func ") && !strings.Contains(line, "HeadPodTemplate") && !strings.Contains(line, "WorkerPodTemplate") {
+			} else if strings.Contains(line, "func ") && !strings.Contains(lowerLine, "headpodtemplate") && !strings.Contains(lowerLine, "workerpodtemplate") {
 				inHeadFunction = false
 				inWorkerFunction = false
 			}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

PATCH [NO JIRA]: reenable openshift e2e tests setup

## Related issue number

<!-- For example: "Closes #1234" -->

## Verification
```
oc login # to an openshift (ROSA|PSI) cluster with 2.23+ RHOAI installed
mkdir -p results # from the root of the repo
# if on mX chip on mac - change podman build command to podman build --arch=amd64 in the Makefile
make build-test-image
podman run --rm -it --pull=never \  
  --platform linux/amd64 \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Sanity,Tier1
```

## Sample output of testing the image
```
podman run --rm -it --pull=never \  
  --platform linux/amd64 \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Sanity,Tier1
Running Sanity and Tier1 kuberay e2e tests
=== RUN   TestRayJobWithClusterSelector
    rayjob_cluster_selector_test.go:27: [2025-09-26T12:33:20Z] Created ConfigMap test-ns-bxccc/jobs successfully
    rayjob_cluster_selector_test.go:35: [2025-09-26T12:33:20Z] Created RayCluster test-ns-bxccc/raycluster successfully
    rayjob_cluster_selector_test.go:37: [2025-09-26T12:33:20Z] Waiting for RayCluster test-ns-bxccc/raycluster to become ready
=== RUN   TestRayJobWithClusterSelector/Successful_RayJob
    rayjob_cluster_selector_test.go:57: [2025-09-26T12:33:57Z] Created RayJob test-ns-bxccc/counter successfully
    rayjob_cluster_selector_test.go:59: [2025-09-26T12:33:57Z] Waiting for RayJob test-ns-bxccc/counter to complete
--- PASS: TestRayJobWithClusterSelector/Successful_RayJob (12.80s)
=== RUN   TestRayJobWithClusterSelector/Failing_RayJob
    rayjob_cluster_selector_test.go:81: [2025-09-26T12:34:10Z] Created RayJob test-ns-bxccc/fail successfully
    rayjob_cluster_selector_test.go:83: [2025-09-26T12:34:10Z] Waiting for RayJob test-ns-bxccc/fail to complete
--- PASS: TestRayJobWithClusterSelector/Failing_RayJob (11.46s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally
    rayjob_cluster_selector_test.go:109: [2025-09-26T12:34:21Z] Created RayJob test-ns-bxccc/managed-externally successfully
--- PASS: TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally (3.21s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value
--- PASS: TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value (0.20s)
    test.go:114: [2025-09-26T12:34:25Z] Retrieving Pod Container test-ns-bxccc/counter-t576r/ray-job-submitter logs
    test.go:102: [2025-09-26T12:34:25Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-26T12:34:25Z] Output directory has been created at: /tmp/TestRayJobWithClusterSelector3872309400/001
    test.go:114: [2025-09-26T12:34:25Z] Retrieving Pod Container test-ns-bxccc/fail-n8vbc/ray-job-submitter logs
    test.go:114: [2025-09-26T12:34:25Z] Retrieving Pod Container test-ns-bxccc/raycluster-head/ray-head logs
    test.go:114: [2025-09-26T12:34:25Z] Retrieving Pod Container test-ns-bxccc/raycluster-head/oauth-proxy logs
    test.go:114: [2025-09-26T12:34:26Z] Retrieving Pod Container test-ns-bxccc/raycluster-small-group-worker-pwkhn/ray-worker logs
--- PASS: TestRayJobWithClusterSelector (67.56s)
=== RUN   TestRayJobLightWeightMode
    rayjob_lightweight_test.go:27: [2025-09-26T12:34:27Z] Created ConfigMap test-ns-4tcpt/jobs successfully
=== RUN   TestRayJobLightWeightMode/Successful_RayJob
    rayjob_lightweight_test.go:56: [2025-09-26T12:34:27Z] Created RayJob test-ns-4tcpt/counter successfully
    rayjob_lightweight_test.go:58: [2025-09-26T12:34:27Z] Waiting for RayJob test-ns-4tcpt/counter to complete
--- PASS: TestRayJobLightWeightMode/Successful_RayJob (37.29s)
=== RUN   TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_lightweight_test.go:90: [2025-09-26T12:35:04Z] Created RayJob test-ns-4tcpt/fail successfully
    rayjob_lightweight_test.go:92: [2025-09-26T12:35:04Z] Waiting for RayJob test-ns-4tcpt/fail to complete
--- PASS: TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished (31.34s)
=== RUN   TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_lightweight_test.go:121: [2025-09-26T12:35:35Z] Created RayJob test-ns-4tcpt/stop successfully
    rayjob_lightweight_test.go:123: [2025-09-26T12:35:35Z] Waiting for RayJob test-ns-4tcpt/stop to be 'Running'
    rayjob_lightweight_test.go:127: [2025-09-26T12:36:26Z] Waiting for RayJob test-ns-4tcpt/stop to be 'Complete'
    rayjob_lightweight_test.go:137: [2025-09-26T12:36:52Z] Deleted RayJob test-ns-4tcpt/stop successfully
--- PASS: TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (77.12s)
    test.go:114: [2025-09-26T12:36:53Z] Retrieving Pod Container test-ns-4tcpt/fail-d59fr-head/ray-head logs
    test.go:102: [2025-09-26T12:36:53Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-26T12:36:53Z] Output directory has been created at: /tmp/TestRayJobLightWeightMode1043471113/001
    test.go:114: [2025-09-26T12:36:53Z] Retrieving Pod Container test-ns-4tcpt/fail-d59fr-head/oauth-proxy logs
    test.go:114: [2025-09-26T12:36:53Z] Retrieving Pod Container test-ns-4tcpt/fail-d59fr-small-group-worker-6pjln/ray-worker logs
    test.go:114: [2025-09-26T12:36:53Z] Retrieving Pod Container test-ns-4tcpt/stop-x69j7-head/ray-head logs
    test.go:114: [2025-09-26T12:36:53Z] Retrieving Pod Container test-ns-4tcpt/stop-x69j7-head/oauth-proxy logs
    test.go:114: [2025-09-26T12:36:54Z] Retrieving Pod Container test-ns-4tcpt/stop-x69j7-small-group-worker-7jpz4/ray-worker logs
    test.go:114: [2025-09-26T12:36:54Z] Error getting logs from container test-ns-4tcpt/stop-x69j7-small-group-worker-7jpz4/ray-worker
--- PASS: TestRayJobLightWeightMode (148.14s)
=== RUN   TestRayJobSuspend
    rayjob_suspend_test.go:27: [2025-09-26T12:36:55Z] Created ConfigMap test-ns-5z6f9/jobs successfully
=== RUN   TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it.
    rayjob_suspend_test.go:41: [2025-09-26T12:36:55Z] Created RayJob test-ns-5z6f9/long-running successfully
    rayjob_suspend_test.go:43: [2025-09-26T12:36:55Z] Waiting for RayJob test-ns-5z6f9/long-running to be 'Running'
    rayjob_suspend_test.go:47: [2025-09-26T12:37:31Z] Suspend the RayJob test-ns-5z6f9/long-running
    rayjob_suspend_test.go:52: [2025-09-26T12:37:32Z] Waiting for RayJob test-ns-5z6f9/long-running to be 'Suspended'
    rayjob_suspend_test.go:68: [2025-09-26T12:37:32Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:78: [2025-09-26T12:38:09Z] Deleted RayJob test-ns-5z6f9/long-running successfully
--- PASS: TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it. (74.83s)
=== RUN   TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it.
    rayjob_suspend_test.go:97: [2025-09-26T12:38:10Z] Created RayJob test-ns-5z6f9/counter successfully
    rayjob_suspend_test.go:99: [2025-09-26T12:38:10Z] Waiting for RayJob test-ns-5z6f9/counter to be 'Suspended'
    rayjob_suspend_test.go:103: [2025-09-26T12:38:10Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:108: [2025-09-26T12:38:10Z] Waiting for RayJob test-ns-5z6f9/counter to complete
    rayjob_suspend_test.go:123: [2025-09-26T12:39:07Z] Deleted RayJob test-ns-5z6f9/counter successfully
--- PASS: TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it. (59.53s)
    test.go:102: [2025-09-26T12:39:10Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-26T12:39:10Z] Output directory has been created at: /tmp/TestRayJobSuspend3541121139/001
--- PASS: TestRayJobSuspend (135.75s)
=== RUN   TestRayJob
    rayjob_test.go:29: [2025-09-26T12:39:10Z] Created ConfigMap test-ns-6gl8d/jobs successfully
=== RUN   TestRayJob/Successful_RayJob
    rayjob_test.go:46: [2025-09-26T12:39:11Z] Created RayJob test-ns-6gl8d/counter successfully
    rayjob_test.go:48: [2025-09-26T12:39:11Z] Waiting for RayJob test-ns-6gl8d/counter to complete
    rayjob_test.go:64: [2025-09-26T12:40:09Z] Checking that the RayJob status info has been set correctly.
    rayjob_test.go:81: [2025-09-26T12:40:09Z] Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.
    rayjob_test.go:91: [2025-09-26T12:40:40Z] Deleted RayJob test-ns-6gl8d/counter successfully
--- PASS: TestRayJob/Successful_RayJob (89.13s)
=== RUN   TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_test.go:105: [2025-09-26T12:40:40Z] Created RayJob test-ns-6gl8d/fail successfully
    rayjob_test.go:107: [2025-09-26T12:40:40Z] Waiting for RayJob test-ns-6gl8d/fail to complete
    rayjob_test.go:130: [2025-09-26T12:41:37Z] Deleted RayJob test-ns-6gl8d/fail successfully
--- PASS: TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished (58.14s)
=== RUN   TestRayJob/Failing_submitter_K8s_Job
    rayjob_test.go:158: [2025-09-26T12:41:38Z] Created RayJob test-ns-6gl8d/fail-k8s-job successfully
    rayjob_test.go:160: [2025-09-26T12:41:38Z] Waiting for RayJob test-ns-6gl8d/fail-k8s-job to complete
    rayjob_test.go:183: [2025-09-26T12:42:54Z] Deleted RayJob test-ns-6gl8d/fail-k8s-job successfully
--- PASS: TestRayJob/Failing_submitter_K8s_Job (75.93s)
=== RUN   TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_test.go:197: [2025-09-26T12:42:54Z] Created RayJob test-ns-6gl8d/stop successfully
    rayjob_test.go:199: [2025-09-26T12:42:54Z] Waiting for RayJob test-ns-6gl8d/stop to be 'Running'
    rayjob_test.go:203: [2025-09-26T12:43:21Z] Waiting for RayJob test-ns-6gl8d/stop to be 'Complete'
    rayjob_test.go:213: [2025-09-26T12:43:59Z] Deleted RayJob test-ns-6gl8d/stop successfully
--- PASS: TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (64.90s)
=== RUN   TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string
    rayjob_test.go:225: [2025-09-26T12:43:59Z] Created RayJob test-ns-6gl8d/invalid-yamlstr successfully
--- PASS: TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string (5.23s)
=== RUN   TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds
    rayjob_test.go:244: [2025-09-26T12:44:04Z] Created RayJob test-ns-6gl8d/long-running successfully
    rayjob_test.go:247: [2025-09-26T12:44:04Z] Waiting for RayJob test-ns-6gl8d/long-running to be 'Complete'
--- PASS: TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds (6.66s)
=== RUN   TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally
    rayjob_test.go:270: [2025-09-26T12:44:11Z] Created RayJob test-ns-6gl8d/managed-externally successfully
    rayjob_test.go:296: [2025-09-26T12:44:12Z] Deleted RayJob test-ns-6gl8d/managed-externally successfully
--- PASS: TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally (1.45s)
    test.go:114: [2025-09-26T12:44:12Z] Retrieving Pod Container test-ns-6gl8d/long-running-mjx2z-head/ray-head logs
    test.go:102: [2025-09-26T12:44:12Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2025-09-26T12:44:12Z] Output directory has been created at: /tmp/TestRayJob824391781/001
    test.go:114: [2025-09-26T12:44:12Z] Retrieving Pod Container test-ns-6gl8d/long-running-mjx2z-head/oauth-proxy logs
    test.go:114: [2025-09-26T12:44:13Z] Retrieving Pod Container test-ns-6gl8d/long-running-mjx2z-small-group-worker-8vk98/ray-worker logs
    test.go:114: [2025-09-26T12:44:13Z] Error getting logs from container test-ns-6gl8d/long-running-mjx2z-small-group-worker-8vk98/ray-worker
--- PASS: TestRayJob (303.25s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2e	654.810s

DONE 20 tests in 654.814s
```

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved resource update reliability with case-insensitive detection for Head/Worker templates.

- Tests
  - Updated E2E test paths and scripts to the new e2e directory.
  - E2E workflow now updates resources from the e2e support file for consistency.

- Chores
  - Enabled automatic workflow runs on dev branch for build/test image and E2E upgrade workflows.
  - Renamed an E2E upgrade job for clarity without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->