### PR TITLE
CARRY: (RHOAIENG-35541): update release version to v1.4.2

### DIFF
--- a/.tekton/odh-kuberay-operator-controller-push.yaml
+++ b/.tekton/odh-kuberay-operator-controller-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-v1.4.0"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "dev"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: opendatahub-release
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kuberay-operator:v1.4.0
+    value: quay.io/opendatahub/kuberay-operator:v1.4.2
   - name: dockerfile
     value: Dockerfile.rhoai
   - name: path-context

--- a/ray-operator/config/component_metadata.yaml
+++ b/ray-operator/config/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: KubeRay
-    version: 1.4.0
+    version: 1.4.2
     repoUrl: https://github.com/ray-project/kuberay

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,2 +1,2 @@
 namespace=opendatahub
-odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.0
+odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

CARRY: (RHOAIENG-35541): update release version to v1.4.2

## Related issue number

[RHOAIENG-35541](https://issues.redhat.com/browse/RHOAIENG-35541)

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded KubeRay Operator to version 1.4.2, aligning metadata and deployment configurations for consistency.
  - Updated container image references to use quay.io/opendatahub/kuberay-operator:v1.4.2, ensuring the latest stability and improvements are applied.
  - Adjusted release pipeline to target the development branch for controller image builds, streamlining ongoing integration workflows.

- Bug Fixes
  - Included fixes and enhancements provided by the KubeRay 1.4.2 release through the operator upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->