### PR TITLE
CARRY: task(RHOAIENG-36092): Add mutating webhook re secure network

### DIFF
--- a/ray-operator/config/certmanager/certificate.yaml
+++ b/ray-operator/config/certmanager/certificate.yaml
@@ -1,21 +1,7 @@
-# The following manifests contain a self-signed issuer CR and a certificate CR.
+# The following manifest contains a certificate CR that references an existing Issuer.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app.kubernetes.io/name: issuer
-    app.kubernetes.io/instance: selfsigned-issuer
-    app.kubernetes.io/component: certificate
-    app.kubernetes.io/created-by: kuberay-operator
-    app.kubernetes.io/part-of: kuberay-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: selfsigned-issuer
-  namespace: system
-spec:
-  selfSigned: {}
----
+# NOTE: This expects a cert-manager Issuer named 'selfsigned-issuer' to already exist in the namespace.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -27,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: kuberay-operator
     app.kubernetes.io/managed-by: kustomize
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
-  namespace: system
+  namespace: ray-system
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   dnsNames:

--- a/ray-operator/config/openshift/certificate-dns-patch.yaml
+++ b/ray-operator/config/openshift/certificate-dns-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+  namespace: system
+spec:
+  dnsNames:
+  - kuberay-webhook-service.$(namespace).svc
+  - kuberay-webhook-service.$(namespace).svc.cluster.local

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -29,7 +29,7 @@ vars:
 
 resources:
 - ray_operator_scc.yaml
-- ../default
+- ../default-with-webhooks
 
 commonLabels:
   app.kubernetes.io/name: kuberay
@@ -37,6 +37,13 @@ commonLabels:
 
 patches:
 # - path: remove_default_namespace.yaml
+- path: certificate-dns-patch.yaml
+  target:
+    group: cert-manager.io
+    version: v1
+    kind: Certificate
+    name: serving-cert
+- path: webhook-namespace-patch.yaml
 - path: kuberay-operator-image-patch.yaml
   target:
     group: apps

--- a/ray-operator/config/openshift/params.yaml
+++ b/ray-operator/config/openshift/params.yaml
@@ -3,3 +3,13 @@ varReference:
     kind: SecurityContextConstraints
   - path: spec/template/spec/containers[]/image
     kind: Deployment
+  - path: spec/dnsNames
+    kind: Certificate
+  - path: webhooks[]/clientConfig/service/namespace
+    kind: MutatingWebhookConfiguration
+  - path: webhooks[]/clientConfig/service/namespace
+    kind: ValidatingWebhookConfiguration
+  - path: metadata/annotations/cert-manager.io~1inject-ca-from
+    kind: MutatingWebhookConfiguration
+  - path: metadata/annotations/cert-manager.io~1inject-ca-from
+    kind: ValidatingWebhookConfiguration

--- a/ray-operator/config/openshift/webhook-namespace-patch.yaml
+++ b/ray-operator/config/openshift/webhook-namespace-patch.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kuberay-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(namespace)/serving-cert
+webhooks:
+- name: mraycluster.kb.io
+  clientConfig:
+    service:
+      name: kuberay-webhook-service
+      namespace: $(namespace)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kuberay-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(namespace)/serving-cert
+webhooks:
+- name: vraycluster.kb.io
+  clientConfig:
+    service:
+      namespace: $(namespace)

--- a/ray-operator/config/webhook/kustomization.yaml
+++ b/ray-operator/config/webhook/kustomization.yaml
@@ -16,5 +16,13 @@ patches:
     kind: ValidatingWebhookConfiguration
     name: validating-webhook-configuration
     version: v1
+- patch: |-
+    - op: replace
+      path: /webhooks/0/clientConfig/service/namespace
+      value: ray-system
+  target:
+    kind: MutatingWebhookConfiguration
+    name: mutating-webhook-configuration
+    version: v1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/ray-operator/config/webhook/manifests.yaml
+++ b/ray-operator/config/webhook/manifests.yaml
@@ -1,5 +1,31 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-ray-io-v1-raycluster
+  failurePolicy: Fail
+  name: mraycluster.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayclusters
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -27,6 +27,9 @@ const (
 	NumWorkerGroupsKey                       = "ray.io/num-worker-groups"
 	KubeRayVersion                           = "ray.io/kuberay-version"
 
+	// NetworkPolicy annotation key - when present on a RayCluster, enables NetworkPolicy creation
+	EnableSecureTrustedNetworkAnnotationKey = "odh.ray.io/secure-trusted-network"
+
 	// In KubeRay, the Ray container must be the first application container in a head or worker Pod.
 	RayContainerIndex = 0
 

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -265,8 +265,10 @@ func main() {
 		"unable to create controller", "controller", "RayJob")
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {
-		exitOnError(webhooks.SetupRayClusterWebhookWithManager(mgr),
-			"unable to create webhook", "webhook", "RayCluster")
+		exitOnError(webhooks.SetupRayClusterDefaulterWithManager(mgr),
+			"unable to create webhook", "webhook", "RayCluster-Defaulter")
+		exitOnError(webhooks.SetupRayClusterValidatorWithManager(mgr),
+			"unable to create webhook", "webhook", "RayCluster-Validator")
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/ray-operator/pkg/webhooks/v1/raycluster_mutating_webhook.go
+++ b/ray-operator/pkg/webhooks/v1/raycluster_mutating_webhook.go
@@ -1,0 +1,45 @@
+package v1
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+// RayClusterDefaulter mutates RayClusters
+type RayClusterDefaulter struct{}
+
+//+kubebuilder:webhook:path=/mutate-ray-io-v1-raycluster,mutating=true,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayclusters,verbs=create;update,versions=v1,name=mraycluster.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomDefaulter = &RayClusterDefaulter{}
+
+// Default implements webhook.CustomDefaulter
+func (d *RayClusterDefaulter) Default(_ context.Context, obj runtime.Object) error {
+	rayCluster := obj.(*rayv1.RayCluster)
+
+	rayclusterlog.Info("default", "name", rayCluster.Name)
+
+	// Initialize annotations map if nil
+	if rayCluster.Annotations == nil {
+		rayCluster.Annotations = make(map[string]string)
+	}
+
+	// Always set the annotation to "true" - enforcing secure trusted network
+	rayCluster.Annotations[utils.EnableSecureTrustedNetworkAnnotationKey] = "true"
+	rayclusterlog.Info("enforcing secure trusted network", "name", rayCluster.Name, "namespace", rayCluster.Namespace)
+
+	return nil
+}
+
+// SetupRayClusterDefaulterWithManager registers the defaulting webhook for RayCluster
+func SetupRayClusterDefaulterWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&rayv1.RayCluster{}).
+		WithDefaulter(&RayClusterDefaulter{}).
+		Complete()
+}

--- a/ray-operator/pkg/webhooks/v1/raycluster_validating_webhook.go
+++ b/ray-operator/pkg/webhooks/v1/raycluster_validating_webhook.go
@@ -22,41 +22,41 @@ var (
 	nameRegex, _  = regexp.Compile("^[a-z]([-a-z0-9]*[a-z0-9])?$")
 )
 
-// SetupRayClusterWebhookWithManager registers the webhook for RayCluster in the manager.
-func SetupRayClusterWebhookWithManager(mgr ctrl.Manager) error {
+// SetupRayClusterValidatorWithManager registers the webhook for RayCluster in the manager.
+func SetupRayClusterValidatorWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&rayv1.RayCluster{}).
-		WithValidator(&RayClusterWebhook{}).
+		WithValidator(&RayClusterValidator{}).
 		Complete()
 }
 
-type RayClusterWebhook struct{}
+type RayClusterValidator struct{}
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-ray-io-v1-raycluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayclusters,verbs=create;update,versions=v1,name=vraycluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RayClusterWebhook{}
+var _ webhook.CustomValidator = &RayClusterValidator{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
-func (w *RayClusterWebhook) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (w *RayClusterValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	rayCluster := obj.(*rayv1.RayCluster)
 	rayclusterlog.Info("validate create", "name", rayCluster.Name)
 	return nil, w.validateRayCluster(rayCluster)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
-func (w *RayClusterWebhook) ValidateUpdate(_ context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+func (w *RayClusterValidator) ValidateUpdate(_ context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
 	rayCluster := newObj.(*rayv1.RayCluster)
 	rayclusterlog.Info("validate update", "name", rayCluster.Name)
 	return nil, w.validateRayCluster(rayCluster)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
-func (w *RayClusterWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (w *RayClusterValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (w *RayClusterWebhook) validateRayCluster(rayCluster *rayv1.RayCluster) error {
+func (w *RayClusterValidator) validateRayCluster(rayCluster *rayv1.RayCluster) error {
 	var allErrs field.ErrorList
 
 	if err := w.validateName(rayCluster); err != nil {
@@ -76,14 +76,14 @@ func (w *RayClusterWebhook) validateRayCluster(rayCluster *rayv1.RayCluster) err
 		rayCluster.Name, allErrs)
 }
 
-func (w *RayClusterWebhook) validateName(rayCluster *rayv1.RayCluster) *field.Error {
+func (w *RayClusterValidator) validateName(rayCluster *rayv1.RayCluster) *field.Error {
 	if !nameRegex.MatchString(rayCluster.Name) {
 		return field.Invalid(field.NewPath("metadata").Child("name"), rayCluster.Name, "name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')")
 	}
 	return nil
 }
 
-func (w *RayClusterWebhook) validateWorkerGroups(rayCluster *rayv1.RayCluster) *field.Error {
+func (w *RayClusterValidator) validateWorkerGroups(rayCluster *rayv1.RayCluster) *field.Error {
 	workerGroupNames := make(map[string]bool)
 
 	for i, workerGroup := range rayCluster.Spec.WorkerGroupSpecs {


### PR DESCRIPTION
## Why are these changes needed?
This PR adds a new mutating webhook to add the new `odh.ray.io/secure-trusted-network` annotation to all RayClusters. This annotation will then be used to activate our various secure network features which replace CFO functionality.

## Verification Steps
### Setup

* First, build this branch using the below command from within the `ray-operator` directory.

```shell
make docker-build IMG=mutating-webhook-test:odh
```

* Now we can load that image into kind using:

```shell
kind load docker-image mutating-webhook-test:odh --name mutating-webhook-test
```

* We need to `ray-operator/config/manager/manager.yaml` to point to our new local image and to set the `imagePullPolicy` to never (this ensures that it falls back to the local image rather than pulling from a registry). You can do this by making the follow adjustment to line 34 and 35:

```shell
image: mutating-webhook-test:odh
imagePullPolicy: Never
```

* We can then install the operator using the below command:

```shell
kubectl apply --server-side -k config/default-with-webhooks
```

* Verify that the operator is in a running state by using the below command:


```shell
kubectl get pods | grep kuberay-operator
```

* You can also verify the presence of the webhooks by running:

```shell
kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration | grep kuberay
```

* We can now create a RayCluster using the below:

```shell
kubectl apply -f config/samples/ray-cluster.sample.yaml -n ray-system
```

* We can now verify the presence of the annotation by checking the RayCluster CR using:

```shell
kubectl describe raycluster raycluster-kuberay -n ray-system
```

## Related issue number

[Jira](https://issues.redhat.com/browse/RHOAIENG-36092) 

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook support for RayCluster resources with automatic validation and default configuration application.
  * Introduced a new annotation to enable secure network policies on RayCluster deployments.

* **Improvements**
  * Enhanced certificate management for webhook security and OpenShift compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->