### PR TITLE
CARRY: refactor isopenshift check

### DIFF
--- a/ray-operator/config/default-with-webhooks/manager_webhook_patch.yaml
+++ b/ray-operator/config/default-with-webhooks/manager_webhook_patch.yaml
@@ -11,10 +11,6 @@ spec:
         env:
         - name: ENABLE_WEBHOOKS
           value: "true"
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/ray-operator/controllers/ray/networkpolicy_controller.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -102,7 +101,7 @@ func (r *NetworkPolicyController) getKubeRayNamespaces(ctx context.Context) []st
 	logger := ctrl.LoggerFrom(ctx).WithName("networkpolicy-controller")
 
 	// On OpenShift, use stricter namespace detection
-	if r.isOpenShift() {
+	if utils.IsOpenShiftCluster() {
 		logger.V(1).Info("Detected OpenShift platform")
 
 		// 1. Check APPLICATION_NAMESPACE env var (set by ODH operator via params.env)
@@ -130,13 +129,6 @@ func (r *NetworkPolicyController) getKubeRayNamespaces(ctx context.Context) []st
 
 	logger.V(1).Info("Using default namespace", "namespace", "ray-system")
 	return []string{"ray-system"}
-}
-
-// isOpenShift checks if the cluster is running on OpenShift
-func (r *NetworkPolicyController) isOpenShift() bool {
-	gvk := routev1.GroupVersion.WithKind("Route")
-	_, err := r.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	return err == nil
 }
 
 // createOrUpdateNetworkPolicy creates or updates a NetworkPolicy

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -425,11 +425,11 @@ func (r *RayClusterReconciler) reconcileIngress(ctx context.Context, instance *r
 		return nil
 	}
 
-	if r.options.IsOpenShift {
-		// This is open shift - create route
+	if utils.ShouldCreateRoute() {
+		// Create OpenShift Route
 		return r.reconcileRouteOpenShift(ctx, instance)
 	}
-	// plain vanilla kubernetes - create ingress
+	// Create Kubernetes Ingress (also used on OpenShift when USE_INGRESS_ON_OPENSHIFT=true)
 	return r.reconcileIngressKubernetes(ctx, instance)
 }
 

--- a/ray-operator/controllers/ray/utils/openshift.go
+++ b/ray-operator/controllers/ray/utils/openshift.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"os"
+	"strings"
+
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// IsOpenShiftCluster detects if the cluster is OpenShift by checking for OpenShift-specific API groups
+func IsOpenShiftCluster() bool {
+	// Check for OpenShift API groups
+	config, err := ctrl.GetConfig()
+	if err != nil || config == nil {
+		return false
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil || discoveryClient == nil {
+		return false
+	}
+
+	apiGroups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return false
+	}
+
+	// Check for multiple OpenShift-specific API groups
+	openshiftGroups := []string{
+		"route.openshift.io",
+		"security.openshift.io",
+		"config.openshift.io",
+	}
+
+	for _, group := range apiGroups.Groups {
+		for _, openshiftGroup := range openshiftGroups {
+			if strings.Contains(group.Name, openshiftGroup) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// ShouldUseIngressOnOpenShift determines if Ingress should be used instead of Route on OpenShift
+func ShouldUseIngressOnOpenShift() bool {
+	return os.Getenv(USE_INGRESS_ON_OPENSHIFT) == "true"
+}
+
+// ShouldCreateRoute determines if a Route should be created based on cluster type and configuration
+func ShouldCreateRoute() bool {
+	return IsOpenShiftCluster() && !ShouldUseIngressOnOpenShift()
+}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -671,36 +670,10 @@ func GetRayClusterNameFromService(svc *corev1.Service) string {
 	return svc.Spec.Selector[RayClusterLabelKey]
 }
 
-// Check where we are running. We are trying to distinguish here whether
-// this is vanilla kubernetes cluster or Openshift
+// GetClusterType returns whether the cluster is OpenShift or not
+// Deprecated: Use IsOpenShiftCluster() instead
 func GetClusterType() bool {
-	if os.Getenv(USE_INGRESS_ON_OPENSHIFT) == "true" {
-		// Environment is set to treat OpenShift cluster as Vanilla Kubernetes
-		return false
-	}
-
-	// The discovery package is used to discover APIs supported by a Kubernetes API server.
-	config, err := ctrl.GetConfig()
-	if err != nil || config == nil {
-		return false
-	}
-
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil || discoveryClient == nil {
-		return false
-	}
-
-	apiGroupList, err := discoveryClient.ServerGroups()
-	if err != nil {
-		return false
-	}
-
-	for _, group := range apiGroupList.Groups {
-		if strings.HasSuffix(group.Name, ".openshift.io") {
-			return true
-		}
-	}
-	return false
+	return IsOpenShiftCluster()
 }
 
 func GetContainerCommand(additionalOptions []string) []string {


### PR DESCRIPTION
This fixes up the openshift check to not be confused by the USE_INGRESS_ON_OPENSHIFT env var
Provides a vanilla openshift check with robust api checks. 
Uses the new mechanism to decide about the route/ingress creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable routing on OpenShift via USE_INGRESS_ON_OPENSHIFT: can prefer Kubernetes Ingress instead of OpenShift Route at runtime.

* **Refactor**
  * Centralized and improved OpenShift detection and routing decision logic; legacy in-place detection deprecated in favor of the new utility-based approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->