### PR TITLE
adding parrlised and test isolation

### DIFF
--- a/ray-operator/test/e2e/raycluster_gcs_ft_test.go
+++ b/ray-operator/test/e2e/raycluster_gcs_ft_test.go
@@ -23,17 +23,19 @@ const (
 )
 
 func TestRayClusterGCSFaultTolerance(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	_ = WithParallel(t)
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
-	testScriptAC := newConfigMap(namespace.Name, files(test, "test_detached_actor_1.py", "test_detached_actor_2.py"))
-	testScript, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), testScriptAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
+	// Create a namespace and ConfigMap
+	test := WithParallel(t)
+	namespace := test.WithNamespace()
+	_, testScript := test.WithConfigMaps("test_detached_actor_1.py", "test_detached_actor_2.py")
 
-	test.T().Run("Test Detached Actor", func(_ *testing.T) {
-		checkRedisDBSize := deployRedis(test, namespace.Name, redisPassword)
+	t.Run("Test Detached Actor", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		checkRedisDBSize := deployRedis(subtest, namespace.Name, redisPassword)
 		defer g.Eventually(checkRedisDBSize, time.Second*30, time.Second).Should(BeEquivalentTo("0"))
 
 		rayClusterSpecAC := rayv1ac.RayClusterSpec().
@@ -62,69 +64,69 @@ func TestRayClusterGCSFaultTolerance(t *testing.T) {
 		rayClusterAC := rayv1ac.RayCluster("raycluster-gcsft", namespace.Name).
 			WithSpec(apply(rayClusterSpecAC, mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](testScript, "/home/ray/samples")))
 
-		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
-		g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutLong).
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutLong).
 			Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
 
-		headPod, err := GetHeadPod(test, rayCluster)
+		headPod, err := GetHeadPod(subtest, rayCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		LogWithTimestamp(test.T(), "HeadPod Name: %s", headPod.Name)
+		LogWithTimestamp(t, "HeadPod Name: %s", headPod.Name)
 
 		rayNamespace := "testing-ray-namespace"
-		LogWithTimestamp(test.T(), "Ray namespace: %s", rayNamespace)
+		LogWithTimestamp(t, "Ray namespace: %s", rayNamespace)
 
-		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_1.py", rayNamespace})
+		ExecPodCmd(subtest, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_1.py", rayNamespace})
 
 		// [Test 1: Kill GCS process to "restart" the head Pod]
 		// Assertion is implement in python, so no furthur handling needed here, and so are other ExecPodCmd
-		stdout, stderr := ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"pkill", "gcs_server"})
-		LogWithTimestamp(test.T(), "pkill gcs_server output - stdout: %s, stderr: %s", stdout.String(), stderr.String())
+		stdout, stderr := ExecPodCmd(subtest, headPod, common.RayHeadContainer, []string{"pkill", "gcs_server"})
+		LogWithTimestamp(t, "pkill gcs_server output - stdout: %s, stderr: %s", stdout.String(), stderr.String())
 
 		// Restart count should eventually become 1, not creating a new pod
 		HeadPodRestartCount := func(p *corev1.Pod) int32 { return p.Status.ContainerStatuses[0].RestartCount }
 		HeadPodContainerReady := func(p *corev1.Pod) bool { return p.Status.ContainerStatuses[0].Ready }
 
-		g.Eventually(HeadPod(test, rayCluster), TestTimeoutMedium).
+		g.Eventually(HeadPod(subtest, rayCluster), TestTimeoutMedium).
 			Should(WithTransform(HeadPodRestartCount, Equal(int32(1))))
-		g.Eventually(HeadPod(test, rayCluster), TestTimeoutMedium).
+		g.Eventually(HeadPod(subtest, rayCluster), TestTimeoutMedium).
 			Should(WithTransform(HeadPodContainerReady, Equal(true)))
 
 		// Pod Status should eventually become Running
 		PodState := func(p *corev1.Pod) string { return string(p.Status.Phase) }
-		g.Eventually(HeadPod(test, rayCluster)).
+		g.Eventually(HeadPod(subtest, rayCluster)).
 			Should(WithTransform(PodState, Equal("Running")))
 
-		headPod, err = GetHeadPod(test, rayCluster)
+		headPod, err = GetHeadPod(subtest, rayCluster)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		expectedOutput := "3"
-		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_2.py", rayNamespace, expectedOutput})
+		ExecPodCmd(subtest, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_2.py", rayNamespace, expectedOutput})
 
 		// Test 2: Delete the head Pod
-		err = test.Client().Core().CoreV1().Pods(namespace.Name).Delete(test.Ctx(), headPod.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Core().CoreV1().Pods(namespace.Name).Delete(subtest.Ctx(), headPod.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 
 		PodUID := func(p *corev1.Pod) string { return string(p.UID) }
-		g.Eventually(HeadPod(test, rayCluster), TestTimeoutMedium).
+		g.Eventually(HeadPod(subtest, rayCluster), TestTimeoutMedium).
 			ShouldNot(WithTransform(PodUID, Equal(string(headPod.UID)))) // Use UID to check if the new head pod is created.
 
-		g.Eventually(HeadPod(test, rayCluster), TestTimeoutMedium).
+		g.Eventually(HeadPod(subtest, rayCluster), TestTimeoutMedium).
 			Should(WithTransform(PodState, Equal("Running")))
 
-		headPod, err = GetHeadPod(test, rayCluster) // Replace the old head pod
+		headPod, err = GetHeadPod(subtest, rayCluster) // Replace the old head pod
 		g.Expect(err).NotTo(HaveOccurred())
 
 		expectedOutput = "4"
 
-		ExecPodCmd(test, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_2.py", rayNamespace, expectedOutput})
+		ExecPodCmd(subtest, headPod, common.RayHeadContainer, []string{"python", "samples/test_detached_actor_2.py", rayNamespace, expectedOutput})
 
-		err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Delete(test.Ctx(), rayCluster.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Delete(subtest.Ctx(), rayCluster.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 	})
 }
@@ -218,16 +220,18 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
-			test := With(t)
-			g := NewWithT(t)
-			namespace := test.NewTestNamespace()
+			t.Parallel()
+			test := WithParallel(t)
+			g := test.Gomega()
+			namespace := test.WithNamespace()
 
 			checkRedisDBSize := deployRedis(test, namespace.Name, tc.redisPassword)
 			defer g.Eventually(checkRedisDBSize, time.Second*30, time.Second).Should(BeEquivalentTo("0"))
 
 			if tc.createSecret {
-				LogWithTimestamp(test.T(), "Creating Redis password secret")
+				LogWithTimestamp(t, "Creating Redis password secret")
 				_, err := test.Client().Core().CoreV1().Secrets(namespace.Name).Apply(
 					test.Ctx(),
 					corev1ac.Secret("redis-password-secret", namespace.Name).
@@ -240,13 +244,13 @@ func TestGcsFaultToleranceOptions(t *testing.T) {
 			rayClusterAC := tc.rayClusterFn(namespace.Name)
 			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 			g.Expect(err).NotTo(HaveOccurred())
-			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+			LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-			LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+			LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
 			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
 
-			LogWithTimestamp(test.T(), "Verifying environment variables on Head Pod")
+			LogWithTimestamp(t, "Verifying environment variables on Head Pod")
 			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), rayCluster.Status.Head.PodName, metav1.GetOptions{})
@@ -300,10 +304,12 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
-			test := With(t)
-			g := NewWithT(t)
-			namespace := test.NewTestNamespace()
+			t.Parallel()
+			test := WithParallel(t)
+			g := test.Gomega()
+			namespace := test.WithNamespace()
 
 			redisPassword := ""
 			require.False(t, tc.redisPasswordEnv != "" && tc.redisPasswordInRayStartParams != "" && tc.redisPasswordInRayStartParams != "$REDIS_PASSWORD", "redisPasswordEnv and redisPasswordInRayStartParams are both set")
@@ -350,13 +356,13 @@ func TestGcsFaultToleranceAnnotations(t *testing.T) {
 			// Apply RayCluster
 			rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
 			g.Expect(err).NotTo(HaveOccurred())
-			LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+			LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-			LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+			LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
 			g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
 				Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
 
-			LogWithTimestamp(test.T(), "Verifying environment variables on Head Pod")
+			LogWithTimestamp(t, "Verifying environment variables on Head Pod")
 			rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Get(test.Ctx(), rayCluster.Name, metav1.GetOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 			headPod, err := test.Client().Core().CoreV1().Pods(namespace.Name).Get(test.Ctx(), rayCluster.Status.Head.PodName, metav1.GetOptions{})

--- a/ray-operator/test/e2e/raycluster_test.go
+++ b/ray-operator/test/e2e/raycluster_test.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -18,193 +16,208 @@ import (
 )
 
 func TestRayClusterManagedBy(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	_ = WithParallel(t)
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
-
-	test.T().Run("Successful creation of cluster, managed by Kuberay Operator", func(t *testing.T) {
+	t.Run("Successful creation of cluster, managed by Kuberay Operator", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace
+		namespace := subtest.WithNamespace()
 
 		rayClusterAC := rayv1ac.RayCluster("raycluster-ok", namespace.Name).
 			WithSpec(newRayClusterSpec().
 				WithManagedBy(utils.KubeRayController))
 
-		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
-		g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
 			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 	})
 
-	test.T().Run("Creation of cluster skipped, managed by Kueue", func(t *testing.T) {
+	t.Run("Creation of cluster skipped, managed by Kueue", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace
+		namespace := subtest.WithNamespace()
 
 		rayClusterAC := rayv1ac.RayCluster("raycluster-skip", namespace.Name).
 			WithSpec(newRayClusterSpec().
 				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
-		rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-		LogWithTimestamp(test.T(), "RayCluster %s/%s will not become ready - not reconciled", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "RayCluster %s/%s will not become ready - not reconciled", rayCluster.Namespace, rayCluster.Name)
 		g.Consistently(func(gg Gomega) {
-			rc, err := RayCluster(test, rayCluster.Namespace, rayCluster.Name)()
+			rc, err := RayCluster(subtest, rayCluster.Namespace, rayCluster.Name)()
 			gg.Expect(err).NotTo(HaveOccurred())
 			gg.Expect(rc.Status.Conditions).To(BeEmpty())
 		}, time.Second*3, time.Millisecond*500).Should(Succeed())
 
 		// Should not to be able to change managedBy field as it's immutable
 		rayClusterAC.Spec.WithManagedBy(utils.KubeRayController)
-		rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		rayCluster, err = subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
 		g.Expect(err).To(HaveOccurred())
-		g.Eventually(RayCluster(test, *rayClusterAC.Namespace, *rayClusterAC.Name)).
+		g.Eventually(RayCluster(subtest, *rayClusterAC.Namespace, *rayClusterAC.Name)).
 			Should(WithTransform(RayClusterManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
 	})
 
-	test.T().Run("Failed creation of cluster, managed by external non supported controller", func(t *testing.T) {
+	t.Run("Failed creation of cluster, managed by external non supported controller", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace
+		namespace := subtest.WithNamespace()
 
 		rayClusterAC := rayv1ac.RayCluster("raycluster-fail", namespace.Name).
 			WithSpec(newRayClusterSpec().
 				WithManagedBy("controller.com/not-supported"))
 
-		_, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+		_, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(errors.IsInvalid(err)).To(BeTrue(), "error: %v", err)
 	})
 }
 
 func TestRayClusterSuspend(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+	t.Run("Suspend and resume cluster", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
 
-	rayClusterAC := rayv1ac.RayCluster("raycluster-suspend", namespace.Name).WithSpec(newRayClusterSpec())
+		// Create a namespace
+		namespace := subtest.WithNamespace()
 
-	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		rayClusterAC := rayv1ac.RayCluster("raycluster-suspend", namespace.Name).WithSpec(newRayClusterSpec())
 
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-	rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(true))
-	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Suspend RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
 
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to be suspended", rayCluster.Namespace, rayCluster.Name)
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterSuspended), MatchCondition(metav1.ConditionTrue, string(rayv1.RayClusterSuspended))))
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionFalse, rayv1.HeadPodNotFound)))
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionFalse, rayv1.RayClusterPodsProvisioning)))
+		rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(true))
+		rayCluster, err = subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Suspend RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-	rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(false))
-	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Resume RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to be suspended", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterSuspended), MatchCondition(metav1.ConditionTrue, string(rayv1.RayClusterSuspended))))
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionFalse, rayv1.HeadPodNotFound)))
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionFalse, rayv1.RayClusterPodsProvisioning)))
 
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to be resumed", rayCluster.Namespace, rayCluster.Name)
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterSuspended), MatchCondition(metav1.ConditionFalse, string(rayv1.RayClusterSuspended))))
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+		rayClusterAC = rayClusterAC.WithSpec(rayClusterAC.Spec.WithSuspend(false))
+		rayCluster, err = subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Resume RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to be resumed", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterSuspended), MatchCondition(metav1.ConditionFalse, string(rayv1.RayClusterSuspended))))
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.HeadPodReady), MatchCondition(metav1.ConditionTrue, rayv1.HeadPodRunningAndReady)))
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterProvisioned), MatchCondition(metav1.ConditionTrue, rayv1.AllPodRunningAndReadyFirstTime)))
+	})
 }
 
 func TestRayClusterWithResourceQuota(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	t.Run("Cluster creation with resource quota", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t).
+			WithResourceQuota("test-quota", "0.1", "0.1Gi")
+		g := subtest.Gomega()
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+		// Create a namespace (resource quota will be created automatically)
+		namespace := subtest.WithNamespace()
 
-	// Create a resource quota
-	CreateResourceQuota(test, namespace.Name, "test-quota", "0.1", "0.1Gi")
+		rayClusterAC := rayv1ac.RayCluster("raycluster-resource-quota", namespace.Name).WithSpec(newRayClusterSpec())
 
-	rayClusterAC := rayv1ac.RayCluster("raycluster-resource-quota", namespace.Name).WithSpec(newRayClusterSpec())
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
 
-	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
-
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to have ReplicaFailure condition", rayCluster.Namespace, rayCluster.Name)
-	g.Eventually(RayCluster(test, namespace.Name, rayCluster.Name), TestTimeoutShort).
-		Should(WithTransform(StatusCondition(rayv1.RayClusterReplicaFailure), MatchConditionContainsMessage(metav1.ConditionTrue, utils.ErrFailedCreateHeadPod.Error(), "forbidden: exceeded quota")))
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to have ReplicaFailure condition", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, namespace.Name, rayCluster.Name), TestTimeoutShort).
+			Should(WithTransform(StatusCondition(rayv1.RayClusterReplicaFailure),
+				MatchConditionContainsMessage(metav1.ConditionTrue, utils.ErrFailedCreateHeadPod.Error(), "forbidden: exceeded quota")))
+	})
 }
 
 func TestRayClusterScalingDown(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	t.Run("Scale down cluster replicas", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		subtest.WithFinalizers("test.kuberay.io/finalizers")
+		g := subtest.Gomega()
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+		// Create a namespace (finalizers will be cleaned up automatically)
+		namespace := subtest.WithNamespace()
 
-	rayClusterAC := rayv1ac.RayCluster("raycluster-scaling-down", namespace.Name).
-		WithSpec(rayv1ac.RayClusterSpec().
-			WithRayVersion(GetRayVersion()).
-			WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
-				WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
-				WithTemplate(headPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))).
-			WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
-				WithReplicas(2).
-				WithMinReplicas(1).
-				WithMaxReplicas(5).
-				WithGroupName("small-group").
-				WithRayStartParams(map[string]string{"num-cpus": "1"}).
-				WithTemplate(workerPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))))
+		rayClusterAC := rayv1ac.RayCluster("raycluster-scaling-down", namespace.Name).
+			WithSpec(rayv1ac.RayClusterSpec().
+				WithRayVersion(GetRayVersion()).
+				WithHeadGroupSpec(rayv1ac.HeadGroupSpec().
+					WithRayStartParams(map[string]string{"dashboard-host": "0.0.0.0"}).
+					WithTemplate(headPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))).
+				WithWorkerGroupSpecs(rayv1ac.WorkerGroupSpec().
+					WithReplicas(2).
+					WithMinReplicas(1).
+					WithMaxReplicas(5).
+					WithGroupName("small-group").
+					WithRayStartParams(map[string]string{"num-cpus": "1"}).
+					WithTemplate(workerPodTemplateApplyConfiguration().WithFinalizers("test.kuberay.io/finalizers"))))
 
-	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", namespace.Name, rayCluster.Name)
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", namespace.Name, rayCluster.Name)
 
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", namespace.Name, rayCluster.Name)
-	g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", namespace.Name, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
-	headPod, err := GetHeadPod(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	workerPods, err := GetWorkerPods(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	allPods := append([]corev1.Pod{*headPod}, workerPods...)
+		headPod, err := GetHeadPod(subtest, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+		workerPods, err := GetWorkerPods(subtest, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
 
-	LogWithTimestamp(test.T(), "Scaling down replicas of RayCluster %s/%s by 1", namespace.Name, rayCluster.Name)
-	rayClusterAC.Spec.WorkerGroupSpecs[0].WithReplicas(1)
-	rayCluster, err = test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred(), "Failed to scale down RayCluster")
+		LogWithTimestamp(t, "Scaling down replicas of RayCluster %s/%s by 1", namespace.Name, rayCluster.Name)
+		rayClusterAC.Spec.WorkerGroupSpecs[0].WithReplicas(1)
+		rayCluster, err = subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred(), "Failed to scale down RayCluster")
 
-	time.Sleep(5 * time.Second)
+		time.Sleep(5 * time.Second)
 
-	headPod, err = GetHeadPod(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(headPod.DeletionTimestamp).To(BeNil(), "Head pod should not have deletionTimestamp")
+		headPod, err = GetHeadPod(subtest, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(headPod.DeletionTimestamp).To(BeNil(), "Head pod should not have deletionTimestamp")
 
-	workerPods, err = GetWorkerPods(test, rayCluster)
-	g.Expect(err).NotTo(HaveOccurred())
-	deletingCount := 0
-	for _, pod := range workerPods {
-		if pod.DeletionTimestamp != nil {
-			deletingCount++
+		workerPods, err = GetWorkerPods(subtest, rayCluster)
+		g.Expect(err).NotTo(HaveOccurred())
+		deletingCount := 0
+		for _, pod := range workerPods {
+			if pod.DeletionTimestamp != nil {
+				deletingCount++
+			}
 		}
-	}
-	g.Expect(deletingCount).To(Equal(1), "Should have only one worker pod having deletionTimestamp")
+		g.Expect(deletingCount).To(Equal(1), "Should have only one worker pod having deletionTimestamp")
 
-	LogWithTimestamp(test.T(), "Removing finalizers from pods")
-	for _, pod := range allPods {
-		patchBytes := []byte(`{"metadata":{"finalizers":[]}}`)
-		_, err := test.Client().Core().CoreV1().Pods(namespace.Name).Patch(test.Ctx(), pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		g.Expect(err).NotTo(HaveOccurred(), "Failed to remove finalizer from pod %s/%s", namespace.Name, pod.Name)
-	}
+		// Finalizers will be cleaned up automatically by WithFinalizers
+	})
 }

--- a/ray-operator/test/e2e/rayjob_cluster_selector_test.go
+++ b/ray-operator/test/e2e/rayjob_cluster_selector_test.go
@@ -14,32 +14,28 @@ import (
 )
 
 func TestRayJobWithClusterSelector(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	_ = WithParallel(t).WithConfigMaps("counter.py", "fail.py")
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
-
-	// Job scripts
-	jobsAC := newConfigMap(namespace.Name, files(test, "counter.py", "fail.py"))
-	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
-
-	// RayCluster
-	rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
-		WithSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")))
-
-	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
-
-	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
-	g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
-		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
-
-	test.T().Run("Successful RayJob", func(t *testing.T) {
+	t.Run("Successful RayJob", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("counter.py", "fail.py")
+		g := subtest.Gomega()
+
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
+
+		// RayCluster
+		rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
+			WithSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")))
+
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
@@ -52,21 +48,39 @@ env_vars:
 `).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
 
 		// Assert the Ray job has completed successfully
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 	})
 
-	test.T().Run("Failing RayJob", func(t *testing.T) {
+	t.Run("Failing RayJob", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("counter.py", "fail.py")
+		g := subtest.Gomega()
+
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
+
+		// RayCluster
+		rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
+			WithSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")))
+
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
@@ -76,21 +90,39 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
 
 		// Assert the Ray job has failed
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 	})
 
-	test.T().Run("RayJob should be created but not to be updated when managed externally", func(_ *testing.T) {
+	t.Run("RayJob should be created but not to be updated when managed externally", func(t *testing.T) {
 		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("counter.py", "fail.py")
+		g := subtest.Gomega()
+
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
+
+		// RayCluster
+		rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
+			WithSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")))
+
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
 
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("managed-externally", namespace.Name).
@@ -104,19 +136,41 @@ env_vars:
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
 				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// Assert the Ray job status has not been updated
 		g.Consistently(func(gg Gomega) {
-			rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+			var err2 error
+			rayJob, err2 = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
+			err = err2
 			gg.Expect(err).ToNot(HaveOccurred())
 			gg.Expect(rayJob.Status.JobDeploymentStatus).To(Equal(rayv1.JobDeploymentStatusNew))
 		}, time.Second*3, time.Millisecond*500).Should(Succeed())
 	})
 
-	test.T().Run("RayJob should not be created due to managedBy invalid value", func(_ *testing.T) {
+	t.Run("RayJob should not be created due to managedBy invalid value", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("counter.py", "fail.py")
+		g := subtest.Gomega()
+
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
+
+		// RayCluster
+		rayClusterAC := rayv1ac.RayCluster("raycluster", namespace.Name).
+			WithSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs")))
+
+		rayCluster, err := subtest.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(subtest.Ctx(), rayClusterAC, TestApplyOptions)
+		g.Expect(err).NotTo(HaveOccurred())
+		LogWithTimestamp(t, "Created RayCluster %s/%s successfully", rayCluster.Namespace, rayCluster.Name)
+
+		LogWithTimestamp(t, "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+		g.Eventually(RayCluster(subtest, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+			Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("managed-externally-invalid", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -129,7 +183,9 @@ env_vars:
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
 				WithManagedBy("invalid.com/controller"))
 
-		_, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		var err3 error
+		_, err3 = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
+		err = err3
 		g.Expect(errors.IsInvalid(err)).To(BeTrue(), "error: %v", err)
 	})
 }

--- a/ray-operator/test/e2e/rayjob_recovery_test.go
+++ b/ray-operator/test/e2e/rayjob_recovery_test.go
@@ -15,19 +15,17 @@ import (
 )
 
 func TestRayJobRecovery(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	test, _ := WithParallel(t).WithConfigMaps("long_running_counter.py")
+	g := test.Gomega()
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+	t.Run("RayJob should recover after pod deletion", func(t *testing.T) {
+		t.Parallel()
+		subtest, jobs := WithParallel(t).WithConfigMaps("long_running_counter.py")
+		g := subtest.Gomega()
 
-	// Job scripts
-	jobsAC := newConfigMap(namespace.Name, files(test, "long_running_counter.py"))
-	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.NewTestNamespace()
 
-	test.T().Run("RayJob should recover after pod deletion", func(_ *testing.T) {
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -39,20 +37,20 @@ env_vars:
 				WithShutdownAfterJobFinishes(true).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to start running", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to start running", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusRunning)))
-		LogWithTimestamp(test.T(), "Find RayJob %s/%s running", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Find RayJob %s/%s running", rayJob.Namespace, rayJob.Name)
 		// wait for the job to run a bit
-		LogWithTimestamp(test.T(), "Sleep RayJob %s/%s 15 seconds", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Sleep RayJob %s/%s 15 seconds", rayJob.Namespace, rayJob.Name)
 		time.Sleep(15 * time.Second)
 
 		// get the running jobpods
-		jobpods, err := test.Client().Core().CoreV1().Pods(namespace.Name).List(test.Ctx(), metav1.ListOptions{
+		jobpods, err := subtest.Client().Core().CoreV1().Pods(namespace.Name).List(subtest.Ctx(), metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("job-name=%s", rayJob.Name),
 		})
 		g.Expect(err).NotTo(HaveOccurred())
@@ -60,17 +58,17 @@ env_vars:
 		// remove the running jobpods
 		propagationPolicy := metav1.DeletePropagationBackground
 		for _, pod := range jobpods.Items {
-			LogWithTimestamp(test.T(), "Delete Pod %s from namespace  %s", pod.Name, rayJob.Namespace)
-			err = test.Client().Core().CoreV1().Pods(namespace.Name).Delete(test.Ctx(), pod.Name, metav1.DeleteOptions{
+			LogWithTimestamp(t, "Delete Pod %s from namespace  %s", pod.Name, rayJob.Namespace)
+			err = subtest.Client().Core().CoreV1().Pods(namespace.Name).Delete(subtest.Ctx(), pod.Name, metav1.DeleteOptions{
 				PropagationPolicy: &propagationPolicy,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 		}
 
-		LogWithTimestamp(test.T(), "Waiting for new pod to be created and running for RayJob %s/%s", namespace.Name, rayJob.Name)
+		LogWithTimestamp(t, "Waiting for new pod to be created and running for RayJob %s/%s", namespace.Name, rayJob.Name)
 		g.Eventually(func() ([]corev1.Pod, error) {
-			pods, err := test.Client().Core().CoreV1().Pods(namespace.Name).List(
-				test.Ctx(),
+			pods, err := subtest.Client().Core().CoreV1().Pods(namespace.Name).List(
+				subtest.Ctx(),
 				metav1.ListOptions{
 					LabelSelector: fmt.Sprintf("job-name=%s", rayJob.Name),
 				},
@@ -86,7 +84,7 @@ env_vars:
 								continue
 							}
 						}
-						LogWithTimestamp(test.T(), "Found new running pod %s/%s", pod.Namespace, pod.Name)
+						LogWithTimestamp(t, "Found new running pod %s/%s", pod.Namespace, pod.Name)
 						return true
 					}
 				}
@@ -94,10 +92,10 @@ env_vars:
 			}, BeTrue()),
 		)
 
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 
-		g.Eventually(RayJob(test, namespace.Name, rayJob.Name), TestTimeoutMedium).
+		g.Eventually(RayJob(subtest, namespace.Name, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 	})
 }

--- a/ray-operator/test/e2e/rayjob_retry_test.go
+++ b/ray-operator/test/e2e/rayjob_retry_test.go
@@ -13,19 +13,22 @@ import (
 )
 
 func TestRayJobRetry(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	test := WithParallel(t)
+	g := test.Gomega()
 
 	// Create a namespace
 	namespace := test.NewTestNamespace()
 
 	// Job scripts
 	jobsAC := newConfigMap(namespace.Name, files(test, "fail.py"))
-	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+	jobs := test.NewConfigMap(namespace.Name, jobsAC.Name, jobsAC.Data)
+	LogWithTimestamp(t, "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
 
-	test.T().Run("Failing RayJob without cluster shutdown after finished", func(_ *testing.T) {
+	t.Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
 		// RayJob: Set RayJob.BackoffLimit to 2
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -37,54 +40,58 @@ func TestRayJobRetry(t *testing.T) {
 				WithShutdownAfterJobFinishes(false).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
 
 		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutLong).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutLong).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
 		// Check whether the controller respects the backoffLimit.
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobFailed, Equal(int32(3))))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
 
-		job, err := test.Client().Core().BatchV1().Jobs(namespace.Name).Get(test.Ctx(), rayJob.Name, metav1.GetOptions{})
+		job, err := subtest.Client().Core().BatchV1().Jobs(namespace.Name).Get(subtest.Ctx(), rayJob.Name, metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(job.Spec.BackoffLimit).To(HaveValue(Equal(int32(1))))
 		g.Expect(job.Status.Failed).To(Equal(int32(0))) // Ray job failures (at the application level) are not counted as K8s job submitter failures; K8s job submitter failures only count for issues like network errors.
 		g.Expect(job.Status.Succeeded).To(Equal(int32(1)))
 
 		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// Assert the RayCluster has been cascade deleted
 		g.Eventually(func() error {
-			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		}, TestTimeoutShort).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 
 		// Assert the submitter Job has been cascade deleted
-		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name), TestTimeoutShort).Should(BeEmpty())
 	})
 
-	test.T().Run("Failing submitter K8s Job", func(_ *testing.T) {
+	t.Run("Failing submitter K8s Job", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
 		// RayJob: Set RayJob.BackoffLimit to 2 & SubmitterConfig.BackoffLimit to 0 to test RayJob level backoffLimit
 		rayJobAC := rayv1ac.RayJob("fail-submitter-k8s-job", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -101,46 +108,50 @@ func TestRayJobRetry(t *testing.T) {
 		// limit, it will be marked as failed. Then, the RayJob should transition to `Failed`.
 		rayJobAC.Spec.SubmitterPodTemplate.Spec.Containers[0].WithCommand("ray", "job", "submit", "--address", "http://do-not-exist:8265", "--", "echo 123")
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
 
 		// Ensure JobDeploymentStatus transit to Failed
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 		// Ensure JobStatus is empty
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
 		// Ensure Reason is SubmissionFailed
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.SubmissionFailed)))
 
 		// Check whether the controller respects the backoffLimit.
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobFailed, Equal(int32(3))))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
 
 		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Assert the RayCluster has been deleted because ShutdownAfterJobFinishes is true.
 		g.Eventually(func() error {
-			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
 		}, TestTimeoutMedium).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 		// Asset submitter Job is not deleted yet
-		g.Eventually(Jobs(test, namespace.Name)).ShouldNot(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name), TestTimeoutShort).ShouldNot(BeEmpty())
 
 		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
+	t.Run("RayJob has passed ActiveDeadlineSeconds", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
 		// RayJob will transition to JobDeploymentStatusFailed
 		// regardless of the value of backoffLimit.
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
@@ -155,25 +166,29 @@ func TestRayJobRetry(t *testing.T) {
 				WithActiveDeadlineSeconds(5).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// The RayJob will transition to `Failed` because it has passed `ActiveDeadlineSeconds`.
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Failed'", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Failed'", rayJob.Namespace, rayJob.Name)
 
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
 
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobFailed, Equal(int32(1))))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
 	})
 
-	test.T().Run("Failing RayJob with HttpMode submission mode", func(_ *testing.T) {
+	t.Run("Failing RayJob with HttpMode submission mode", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
 		// Set up the RayJob with HTTP mode and a BackoffLimit
 		rayJobAC := rayv1ac.RayJob("failing-rayjob-in-httpmode", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -183,33 +198,33 @@ func TestRayJobRetry(t *testing.T) {
 				WithShutdownAfterJobFinishes(false).
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
 
 		// Assert that the RayJob deployment status has been updated.
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
 
 		// Assert the Ray job has failed.
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
 		// Check the RayJob reason has been updated.
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 
 		// Check whether the controller respects the backoffLimit.
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobFailed, Equal(int32(3)))) // 2 retries + 1 initial attempt = 3 failures
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobSucceeded, Equal(int32(0))))
 
 		// Clean up
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 }

--- a/ray-operator/test/e2e/rayjob_suspend_test.go
+++ b/ray-operator/test/e2e/rayjob_suspend_test.go
@@ -14,19 +14,17 @@ import (
 )
 
 func TestRayJobSuspend(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	_ = WithParallel(t).WithConfigMaps("long_running.py", "counter.py")
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+	t.Run("Suspend the RayJob when its status is 'Running', and then resume it.", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("long_running.py", "counter.py")
+		g := subtest.Gomega()
 
-	// Job scripts
-	jobsAC := newConfigMap(namespace.Name, files(test, "long_running.py", "counter.py"))
-	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
 
-	test.T().Run("Suspend the RayJob when its status is 'Running', and then resume it.", func(_ *testing.T) {
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -36,49 +34,54 @@ func TestRayJobSuspend(t *testing.T) {
 				WithTTLSecondsAfterFinished(600).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
 
-		LogWithTimestamp(test.T(), "Suspend the RayJob %s/%s", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Suspend the RayJob %s/%s", rayJob.Namespace, rayJob.Name)
 		rayJobAC.Spec.WithSuspend(true)
-		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusSuspended)))
 
-		// TODO (kevin85421): We may need to use `Eventually` instead if the assertion is flaky.
 		// Assert the RayCluster has been torn down
-		_, err = GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
-		g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		g.Eventually(func() error {
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
+			return err
+		}, TestTimeoutShort).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 
 		// Assert the submitter Job has been cascade deleted
-		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name), TestTimeoutShort).Should(BeEmpty())
 
-		// TODO (kevin85421): Check whether the Pods associated with the RayCluster and the submitter Job have been deleted.
-		// For Kubernetes Jobs, the default deletion behavior is "orphanDependents," which means the Pods will not be
-		// cascade-deleted with the Kubernetes Job by default.
-
-		LogWithTimestamp(test.T(), "Resume the RayJob by updating `suspend` to false.")
+		LogWithTimestamp(t, "Resume the RayJob by updating `suspend` to false.")
 		rayJobAC.Spec.WithSuspend(false)
-		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
 
 		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Create a suspended RayJob, and then resume it.", func(_ *testing.T) {
+	t.Run("Create a suspended RayJob, and then resume it.", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		jobs := subtest.WithConfigMaps("long_running.py", "counter.py")
+		g := subtest.Gomega()
+
+		// Create a namespace (ConfigMap will be created automatically)
+		namespace := subtest.WithNamespace()
+
 		// RayJob
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
@@ -92,45 +95,45 @@ env_vars:
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Suspended'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusSuspended)))
 
-		LogWithTimestamp(test.T(), "Resume the RayJob by updating `suspend` to false.")
+		LogWithTimestamp(t, "Resume the RayJob by updating `suspend` to false.")
 		rayJobAC.Spec.WithSuspend(false)
-		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 
 		// Assert the RayJob has completed successfully
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 
 		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
 		// Assert the RayCluster has been cascade deleted
 		g.Eventually(func() error {
-			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		}, TestTimeoutShort).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 
 		// Assert the Pods has been cascade deleted
-		g.Eventually(Pods(test, namespace.Name,
-			LabelSelector(utils.RayClusterLabelKey+"="+rayJob.Status.RayClusterName))).
+		g.Eventually(Pods(subtest, namespace.Name,
+			LabelSelector(utils.RayClusterLabelKey+"="+rayJob.Status.RayClusterName)), TestTimeoutShort).
 			Should(BeEmpty())
 	})
 }

--- a/ray-operator/test/e2e/rayjob_test.go
+++ b/ray-operator/test/e2e/rayjob_test.go
@@ -16,20 +16,19 @@ import (
 )
 
 func TestRayJob(t *testing.T) {
-	test := With(t)
-	g := NewWithT(t)
+	_ = WithParallel(t)
 
-	// Create a namespace
-	namespace := test.NewTestNamespace()
+	// Each test will create its own namespace and ConfigMap
 
-	// Job scripts
-	jobsAC := newConfigMap(namespace.Name, files(test, "counter.py", "fail.py", "stop.py", "long_running.py"))
-	jobs, err := test.Client().Core().CoreV1().ConfigMaps(namespace.Name).Apply(test.Ctx(), jobsAC, TestApplyOptions)
-	g.Expect(err).NotTo(HaveOccurred())
-	LogWithTimestamp(test.T(), "Created ConfigMap %s/%s successfully", jobs.Namespace, jobs.Name)
+	t.Run("Successful RayJob", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
 
-	test.T().Run("Successful RayJob", func(_ *testing.T) {
-		// RayJob
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("counter", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -41,58 +40,55 @@ env_vars:
 				WithShutdownAfterJobFinishes(true).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
 
-		// Assert the RayJob has completed successfully
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusSucceeded)))
 
-		// And the RayJob deployment status is updated accordingly
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 
-		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		LogWithTimestamp(test.T(), "Checking that the RayJob status info has been set correctly.")
+		LogWithTimestamp(t, "Checking that the RayJob status info has been set correctly.")
 		g.Expect(rayJob.Status.RayJobStatusInfo.StartTime).NotTo(BeNil())
 		g.Expect(rayJob.Status.RayJobStatusInfo.EndTime).NotTo(BeNil())
 
-		// Assert the RayCluster has been torn down
 		g.Eventually(func() error {
-			_, err = GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err = GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
 		}, TestTimeoutShort).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 
-		// Assert the submitter Job has not been deleted
-		g.Eventually(Jobs(test, namespace.Name)).ShouldNot(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name)).ShouldNot(BeEmpty())
 
-		// TODO (kevin85421): Check whether the Pods associated with the RayCluster and the submitter Job have been deleted.
-		// For Kubernetes Jobs, the default deletion behavior is "orphanDependents," which means the Pods will not be
-		// cascadingly deleted with the Kubernetes Job by default.
-
-		LogWithTimestamp(test.T(), "Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.")
+		LogWithTimestamp(t, "Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.")
 		rayJobAC.Spec.WithSuspend(true)
-		rayJob, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Consistently(RayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Consistently(RayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 
-		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Failing RayJob without cluster shutdown after finished", func(_ *testing.T) {
-		// RayJob
+	t.Run("Failing RayJob without cluster shutdown after finished", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("fail", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -100,47 +96,46 @@ env_vars:
 				WithShutdownAfterJobFinishes(false).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobStatus, Satisfy(rayv1.IsJobTerminal)))
 
-		// Assert the Ray job has failed
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusFailed)))
 
-		// Assert that the RayJob deployment status and RayJob reason have been updated accordingly.
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.AppFailed)))
 
-		// TODO (kevin85421): Ensure the RayCluster and Kubernetes Job are not deleted because `ShutdownAfterJobFinishes` is false.
-
-		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		// Assert the RayCluster has been cascade deleted
 		g.Eventually(func() error {
-			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		}, TestTimeoutShort).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
 
-		// Assert the submitter Job has been cascade deleted
-		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name), TestTimeoutShort).Should(BeEmpty())
 	})
 
-	test.T().Run("Failing submitter K8s Job", func(_ *testing.T) {
-		// RayJob
+	t.Run("Failing submitter K8s Job", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("fail-k8s-job", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -148,88 +143,100 @@ env_vars:
 				WithShutdownAfterJobFinishes(true).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		// In this test, we try to simulate the case where the submitter Job can't connect to the RayCluster successfully.
-		// Hence, KubeRay can't get the Ray job information from the RayCluster. When the submitter Job reaches the backoff
-		// limit, it will be marked as failed. Then, the RayJob should transition to `Complete`.
 		rayJobAC.Spec.SubmitterPodTemplate.Spec.Containers[0].WithCommand("ray", "job", "submit", "--address", "http://do-not-exist:8265", "--", "echo 123")
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to complete", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusNew)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.SubmissionFailed)))
 
-		// Refresh the RayJob status
-		rayJob, err = GetRayJob(test, rayJob.Namespace, rayJob.Name)
+		rayJob, err = GetRayJob(subtest, rayJob.Namespace, rayJob.Name)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Assert the RayCluster has been deleted because ShutdownAfterJobFinishes is true.
 		g.Eventually(func() error {
-			_, err := GetRayCluster(test, namespace.Name, rayJob.Status.RayClusterName)
+			_, err := GetRayCluster(subtest, namespace.Name, rayJob.Status.RayClusterName)
 			return err
-		}).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
-		// Asset submitter Job is not deleted yet
-		g.Eventually(Jobs(test, namespace.Name)).ShouldNot(BeEmpty())
+		}, TestTimeoutMedium).Should(WithTransform(k8serrors.IsNotFound, BeTrue()))
+		g.Eventually(Jobs(subtest, namespace.Name), TestTimeoutShort).ShouldNot(BeEmpty())
 
-		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("Should transition to 'Complete' if the Ray job has stopped.", func(_ *testing.T) {
-		// `stop.py` will sleep for 20 seconds so that the RayJob has enough time to transition to `RUNNING`
-		// and then stop the Ray job. If the Ray job is stopped, the RayJob should transition to `Complete`.
+	t.Run("Should transition to 'Complete' if the Ray job has stopped", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("stop", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithEntrypoint("python /home/ray/jobs/stop.py").
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Running'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusRunning)))
 
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
+		LogWithTimestamp(t, "Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutMedium).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusComplete)))
 
-		// Refresh the RayJob status
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusStopped)))
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).To(WithTransform(RayJobStatus, Equal(rayv1.JobStatusStopped)))
 
-		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), rayJob.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), rayJob.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 	})
 
-	test.T().Run("RuntimeEnvYAML is not a valid YAML string", func(_ *testing.T) {
+	t.Run("RuntimeEnvYAML is not a valid YAML string", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("invalid-yamlstr", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithEntrypoint("python /home/ray/jobs/counter.py").
 				WithRuntimeEnvYAML(`invalid_yaml_string`).
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		// `RuntimeEnvYAML` is not a valid YAML string, so the RayJob controller will not do anything with the CR.
-		g.Consistently(RayJob(test, rayJob.Namespace, rayJob.Name), 5*time.Second).
+		g.Consistently(RayJob(subtest, rayJob.Namespace, rayJob.Name), 5*time.Second).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusNew)))
 	})
 
-	test.T().Run("RayJob has passed ActiveDeadlineSeconds", func(_ *testing.T) {
+	t.Run("RayJob has passed ActiveDeadlineSeconds", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("long-running", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -239,20 +246,25 @@ env_vars:
 				WithActiveDeadlineSeconds(5).
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		// The RayJob will transition to `Complete` because it has passed `ActiveDeadlineSeconds`.
-		LogWithTimestamp(test.T(), "Waiting for RayJob %s/%s to be 'Complete'", rayJob.Namespace, rayJob.Name)
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name), TestTimeoutShort).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusFailed)))
-		g.Expect(GetRayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Expect(GetRayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			To(WithTransform(RayJobReason, Equal(rayv1.DeadlineExceeded)))
 	})
 
-	test.T().Run("RayJob should be created, but not updated when managed externally", func(_ *testing.T) {
-		// RayJob
+	t.Run("RayJob should be created but not updated when managed externally", func(t *testing.T) {
+		t.Parallel()
+		subtest := WithParallel(t)
+		g := subtest.Gomega()
+
+		// Create a namespace and ConfigMap
+		namespace := subtest.WithNamespace()
+		_, jobs := subtest.WithConfigMaps("counter.py", "fail.py", "stop.py", "long_running.py")
+
 		rayJobAC := rayv1ac.RayJob("managed-externally", namespace.Name).
 			WithSpec(rayv1ac.RayJobSpec().
 				WithRayClusterSpec(newRayClusterSpec(mountConfigMap[rayv1ac.RayClusterSpecApplyConfiguration](jobs, "/home/ray/jobs"))).
@@ -265,34 +277,29 @@ env_vars:
 				WithSubmitterPodTemplate(jobSubmitterPodTemplateApplyConfiguration()).
 				WithManagedBy("kueue.x-k8s.io/multikueue"))
 
-		rayJob, err := test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		rayJob, err := subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
+		LogWithTimestamp(t, "Created RayJob %s/%s successfully", rayJob.Namespace, rayJob.Name)
 
-		// Should not to be able to change managedBy field as it's immutable
 		rayJobAC.Spec.WithManagedBy(utils.KubeRayController)
-		_, err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(test.Ctx(), rayJobAC, TestApplyOptions)
+		_, err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Apply(subtest.Ctx(), rayJobAC, TestApplyOptions)
 		g.Expect(err).To(HaveOccurred())
-		g.Eventually(RayJob(test, *rayJobAC.Namespace, *rayJobAC.Name)).
+		g.Eventually(RayJob(subtest, *rayJobAC.Namespace, *rayJobAC.Name)).
 			Should(WithTransform(RayJobManagedBy, Equal(ptr.To("kueue.x-k8s.io/multikueue"))))
 
-		// Refresh the RayJob status and assert it has not been updated
-		g.Eventually(RayJob(test, rayJob.Namespace, rayJob.Name)).
+		g.Eventually(RayJob(subtest, rayJob.Namespace, rayJob.Name)).
 			Should(WithTransform(RayJobDeploymentStatus, Equal(rayv1.JobDeploymentStatusNew)))
 
-		// Assert the associated RayCluster has not beed created
-		rcList, err := test.Client().Ray().RayV1().RayClusters(rayJob.Namespace).List(test.Ctx(), metav1.ListOptions{})
+		rcList, err := subtest.Client().Ray().RayV1().RayClusters(rayJob.Namespace).List(subtest.Ctx(), metav1.ListOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		for _, rc := range rcList.Items {
 			g.Expect(rc.Name).NotTo(HaveSuffix(*rayJobAC.Name))
 		}
 
-		// Assert the submitter Job has not been created
-		g.Eventually(Jobs(test, namespace.Name)).Should(BeEmpty())
+		g.Eventually(Jobs(subtest, namespace.Name)).Should(BeEmpty())
 
-		// Delete the RayJob
-		err = test.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(test.Ctx(), *rayJobAC.Name, metav1.DeleteOptions{})
+		err = subtest.Client().Ray().RayV1().RayJobs(namespace.Name).Delete(subtest.Ctx(), *rayJobAC.Name, metav1.DeleteOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
-		LogWithTimestamp(test.T(), "Deleted RayJob %s/%s successfully", *rayJobAC.Namespace, *rayJobAC.Name)
+		LogWithTimestamp(t, "Deleted RayJob %s/%s successfully", *rayJobAC.Namespace, *rayJobAC.Name)
 	})
 }

--- a/ray-operator/test/support/log.go
+++ b/ray-operator/test/support/log.go
@@ -1,0 +1,16 @@
+package support
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// LogWithTimestamp logs a message with a timestamp prefix
+// This is useful for debugging test failures by showing when each event occurred
+func LogWithTimestamp(t *testing.T, format string, args ...interface{}) {
+	t.Helper()
+	timestamp := time.Now().Format("15:04:05.000")
+	message := fmt.Sprintf(format, args...)
+	t.Logf("[%s] %s", timestamp, message)
+}

--- a/ray-operator/test/support/parallel_test.go
+++ b/ray-operator/test/support/parallel_test.go
@@ -1,0 +1,322 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// ParallelTest represents a test that can be run in parallel with other tests
+type ParallelTest struct {
+	t             *testing.T
+	ctx           context.Context
+	client        Client
+	cleanup       []func()
+	beforeEachFns []func(namespace *corev1.Namespace) error
+}
+
+// WithParallel creates a new ParallelTest that is safe to run in parallel with other tests
+func WithParallel(t *testing.T) *ParallelTest {
+	t.Helper()
+	t.Parallel() // Mark test as parallel
+
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		withDeadline, cancel := context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+		ctx = withDeadline
+	}
+
+	pt := &ParallelTest{
+		t:             t,
+		ctx:           ctx,
+		cleanup:       make([]func(), 0),
+		beforeEachFns: make([]func(namespace *corev1.Namespace) error, 0),
+	}
+
+	// Create a new client for this test
+	c, err := newTestClient()
+	if err != nil {
+		t.Fatalf("Error creating client: %v", err)
+	}
+	pt.client = c
+
+	// Register cleanup to run in reverse order
+	t.Cleanup(func() {
+		for i := len(pt.cleanup) - 1; i >= 0; i-- {
+			pt.cleanup[i]()
+		}
+	})
+
+	return pt
+}
+
+// NewTestNamespace creates a new namespace for this test with a unique name
+func (pt *ParallelTest) NewTestNamespace(opts ...Option[*corev1.Namespace]) *corev1.Namespace {
+	pt.t.Helper()
+
+	name := fmt.Sprintf("test-%s", pt.t.Name())
+	name = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			return r
+		}
+		return '-'
+	}, name)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	name = strings.TrimSuffix(name, "-")
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(namespace)
+	}
+
+	namespace, err := pt.client.Core().CoreV1().Namespaces().Create(pt.ctx, namespace, metav1.CreateOptions{})
+	if err != nil {
+		pt.t.Fatalf("Error creating namespace: %v", err)
+	}
+
+	for _, fn := range pt.beforeEachFns {
+		if err := fn(namespace); err != nil {
+			pt.t.Fatalf("BeforeEach failed: %v", err)
+		}
+	}
+
+	pt.cleanup = append(pt.cleanup, func() {
+		storeAllPodLogs(pt, namespace)
+		storeEvents(pt, namespace)
+
+		err := pt.client.Core().CoreV1().Namespaces().Delete(pt.ctx, namespace.Name, metav1.DeleteOptions{})
+		if err != nil {
+			pt.t.Errorf("Error deleting namespace: %v", err)
+		}
+	})
+
+	return namespace
+}
+
+// NewConfigMap creates a new ConfigMap in the given namespace
+func (pt *ParallelTest) NewConfigMap(namespace string, name string, data map[string]string) *corev1.ConfigMap {
+	pt.t.Helper()
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+
+	cm, err := pt.client.Core().CoreV1().ConfigMaps(namespace).Create(pt.ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		pt.t.Fatalf("Error creating ConfigMap: %v", err)
+	}
+
+	pt.cleanup = append(pt.cleanup, func() {
+		err := pt.client.Core().CoreV1().ConfigMaps(namespace).Delete(pt.ctx, name, metav1.DeleteOptions{})
+		if err != nil {
+			pt.t.Errorf("Error deleting ConfigMap: %v", err)
+		}
+	})
+
+	return cm
+}
+
+// Gomega returns a new Gomega instance for this test
+func (pt *ParallelTest) Gomega() *gomega.WithT {
+	return gomega.NewWithT(pt.t)
+}
+
+// T returns the testing.T instance
+func (pt *ParallelTest) T() *testing.T {
+	return pt.t
+}
+
+// Ctx returns the context for this test
+func (pt *ParallelTest) Ctx() context.Context {
+	return pt.ctx
+}
+
+// Client returns the Kubernetes client for this test
+func (pt *ParallelTest) Client() Client {
+	return pt.client
+}
+
+// OutputDir returns the output directory for test artifacts
+func (pt *ParallelTest) OutputDir() string {
+	return filepath.Join("test", "output", pt.t.Name())
+}
+
+// BeforeEach registers a function to be run before each test case
+// The function will be run after namespace creation but before the test starts
+func (pt *ParallelTest) BeforeEach(fn func(namespace *corev1.Namespace) error) *ParallelTest {
+	pt.t.Helper()
+	pt.beforeEachFns = append(pt.beforeEachFns, fn)
+	return pt
+}
+
+// testContext holds test-specific data that needs to be shared between BeforeEach and the test
+type testContext struct {
+	configMap *corev1.ConfigMap
+	namespace *corev1.Namespace
+}
+
+// WithNamespace creates a new namespace with a unique name based on the test name
+// This is a convenience wrapper around BeforeEach for creating and cleaning up namespaces
+func (pt *ParallelTest) WithNamespace() *corev1.Namespace {
+	name := fmt.Sprintf("test-%s", pt.t.Name())
+	name = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			return r
+		}
+		return '-'
+	}, name)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	name = strings.TrimSuffix(name, "-")
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	namespace, err := pt.client.Core().CoreV1().Namespaces().Create(pt.ctx, namespace, metav1.CreateOptions{})
+	if err != nil {
+		pt.t.Fatalf("Error creating namespace: %v", err)
+	}
+
+	pt.cleanup = append(pt.cleanup, func() {
+		storeAllPodLogs(pt, namespace)
+		storeEvents(pt, namespace)
+
+		err := pt.client.Core().CoreV1().Namespaces().Delete(pt.ctx, namespace.Name, metav1.DeleteOptions{})
+		if err != nil {
+			pt.t.Errorf("Error deleting namespace: %v", err)
+		}
+	})
+
+	return namespace
+}
+
+// WithConfigMaps creates ConfigMaps in the test namespace with the given files
+// This is a convenience wrapper around BeforeEach for the common case of creating ConfigMaps
+func (pt *ParallelTest) WithConfigMaps(fileNames ...string) *corev1.ConfigMap {
+	var ctx testContext
+	pt.BeforeEach(func(namespace *corev1.Namespace) error {
+		name := fmt.Sprintf("test-%s", pt.t.Name())
+		name = strings.Map(func(r rune) rune {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+				return r
+			}
+			return '-'
+		}, name)
+		if len(name) > 63 {
+			name = name[:63]
+		}
+		name = strings.TrimSuffix(name, "-")
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace.Name,
+			},
+			Data: make(map[string]string),
+		}
+
+		for _, fileName := range fileNames {
+			data, err := os.ReadFile(filepath.Join("test", "data", fileName))
+			if err != nil {
+				pt.t.Fatalf("Error reading file %s: %v", fileName, err)
+			}
+			configMap.Data[fileName] = string(data)
+		}
+
+		configMap, err := pt.client.Core().CoreV1().ConfigMaps(namespace.Name).Create(pt.ctx, configMap, metav1.CreateOptions{})
+		if err != nil {
+			pt.t.Fatalf("Error creating ConfigMap: %v", err)
+		}
+
+		pt.cleanup = append(pt.cleanup, func() {
+			err := pt.client.Core().CoreV1().ConfigMaps(namespace.Name).Delete(pt.ctx, configMap.Name, metav1.DeleteOptions{})
+			if err != nil {
+				pt.t.Errorf("Error deleting ConfigMap: %v", err)
+			}
+		})
+
+		ctx.configMap = configMap
+		return nil
+	})
+	return ctx.configMap
+}
+
+// WithResourceQuota creates a resource quota in the test namespace
+// This is a convenience wrapper around BeforeEach for the common case of creating resource quotas
+func (pt *ParallelTest) WithResourceQuota(name string, cpu string, memory string) {
+	pt.BeforeEach(func(namespace *corev1.Namespace) error {
+		quota := &corev1.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace.Name,
+			},
+			Spec: corev1.ResourceQuotaSpec{
+				Hard: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse(cpu),
+					corev1.ResourceMemory: resource.MustParse(memory),
+				},
+			},
+		}
+
+		quota, err := pt.client.Core().CoreV1().ResourceQuotas(namespace.Name).Create(pt.ctx, quota, metav1.CreateOptions{})
+		if err != nil {
+			pt.t.Fatalf("Error creating resource quota: %v", err)
+		}
+
+		pt.cleanup = append(pt.cleanup, func() {
+			err := pt.client.Core().CoreV1().ResourceQuotas(namespace.Name).Delete(pt.ctx, quota.Name, metav1.DeleteOptions{})
+			if err != nil {
+				pt.t.Errorf("Error deleting resource quota: %v", err)
+			}
+		})
+
+		return nil
+	})
+}
+
+// WithFinalizers adds finalizers to the given pod templates
+// This is a convenience wrapper around BeforeEach for the common case of adding finalizers
+func (pt *ParallelTest) WithFinalizers(finalizer string) {
+	pt.BeforeEach(func(namespace *corev1.Namespace) error {
+		pt.cleanup = append(pt.cleanup, func() {
+			pods, err := pt.client.Core().CoreV1().Pods(namespace.Name).List(pt.ctx, metav1.ListOptions{})
+			if err != nil {
+				pt.t.Errorf("Error listing pods: %v", err)
+				return
+			}
+			for _, pod := range pods.Items {
+				patchBytes := []byte(`{"metadata":{"finalizers":[]}}`)
+				_, err := pt.client.Core().CoreV1().Pods(namespace.Name).Patch(pt.ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				if err != nil {
+					pt.t.Errorf("Error removing finalizer from pod %s/%s: %v", namespace.Name, pod.Name, err)
+				}
+			}
+		})
+		return nil
+	})
+}

--- a/ray-operator/test/support/test.go
+++ b/ray-operator/test/support/test.go
@@ -2,123 +2,35 @@ package support
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
+// Option is a function that modifies a value of type T
+// This pattern allows for flexible configuration of objects with optional settings
+type Option[T any] func(T)
+
+// Test represents a test that can be run in parallel with other tests
+// This interface defines the minimum set of methods required for test isolation
 type Test interface {
+	// T returns the testing.T instance for this test
 	T() *testing.T
+
+	// Ctx returns the context for this test
+	// The context is automatically cancelled when the test completes
 	Ctx() context.Context
+
+	// Client returns the Kubernetes client for this test
+	// Each test gets its own client to avoid interference
 	Client() Client
+
+	// OutputDir returns the output directory for test artifacts
+	// Each test gets its own directory to avoid conflicts
 	OutputDir() string
 
-	NewTestNamespace(...Option[*corev1.Namespace]) *corev1.Namespace
-}
-
-type Option[T any] interface {
-	applyTo(to T) error
-}
-
-type errorOption[T any] func(to T) error
-
-func (o errorOption[T]) applyTo(to T) error {
-	return o(to)
-}
-
-var _ Option[any] = errorOption[any](nil)
-
-func With(t *testing.T) Test {
-	t.Helper()
-	ctx := context.Background()
-	if deadline, ok := t.Deadline(); ok {
-		withDeadline, cancel := context.WithDeadline(ctx, deadline)
-		t.Cleanup(cancel)
-		ctx = withDeadline
-	}
-
-	return &T{
-		t:   t,
-		ctx: ctx,
-	}
-}
-
-type T struct {
-	t *testing.T
-	//nolint:containedctx //nolint:nolintlint // TODO: The reason for this lint is unknown
-	ctx       context.Context
-	client    Client
-	outputDir string
-	once      struct {
-		client    sync.Once
-		outputDir sync.Once
-	}
-}
-
-func (t *T) T() *testing.T {
-	return t.t
-}
-
-func (t *T) Ctx() context.Context {
-	return t.ctx
-}
-
-func (t *T) Client() Client {
-	t.T().Helper()
-	t.once.client.Do(func() {
-		c, err := newTestClient()
-		if err != nil {
-			t.T().Fatalf("Error creating client: %v", err)
-		}
-		t.client = c
-	})
-	return t.client
-}
-
-func (t *T) OutputDir() string {
-	t.T().Helper()
-	t.once.outputDir.Do(func() {
-		if parent, ok := os.LookupEnv(KuberayTestOutputDir); ok {
-			if !path.IsAbs(parent) {
-				if cwd, err := os.Getwd(); err == nil {
-					// best effort to output the parent absolute path
-					parent = path.Join(cwd, parent)
-				}
-			}
-			LogWithTimestamp(t.T(), "Creating output directory in parent directory: %s", parent)
-			safeName := strings.ReplaceAll(t.T().Name(), "/", "_")
-			dir, err := os.MkdirTemp(parent, safeName)
-			if err != nil {
-				t.T().Fatalf("Error creating output directory: %v", err)
-			}
-			t.outputDir = dir
-		} else {
-			LogWithTimestamp(t.T(), "Creating ephemeral output directory as %s env variable is unset", KuberayTestOutputDir)
-			t.outputDir = t.T().TempDir()
-		}
-		LogWithTimestamp(t.T(), "Output directory has been created at: %s", t.outputDir)
-	})
-	return t.outputDir
-}
-
-func (t *T) NewTestNamespace(options ...Option[*corev1.Namespace]) *corev1.Namespace {
-	t.T().Helper()
-	namespace := createTestNamespace(t, options...)
-	t.T().Cleanup(func() {
-		storeAllPodLogs(t, namespace)
-		storeEvents(t, namespace)
-		deleteTestNamespace(t, namespace)
-	})
-	return namespace
-}
-
-func LogWithTimestamp(t *testing.T, format string, args ...interface{}) {
-	t.Helper()
-	t.Logf("[%s] %s", time.Now().Format(time.RFC3339), fmt.Sprintf(format, args...))
+	// NewTestNamespace creates a new namespace for this test with a unique name
+	// The namespace is automatically cleaned up when the test completes
+	// Options can be provided to customize the namespace
+	NewTestNamespace(opts ...Option[*corev1.Namespace]) *corev1.Namespace
 }


### PR DESCRIPTION
some suggested changes to improve flaky e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored end-to-end suite to run parallel, isolated subtests with per-test namespaces and resource management, improving speed and reliability.
  * Converted many linear tests into nested parallel scenarios to increase isolation and concurrency.

* **Refactor**
  * Added a parallel test harness with helpers for per-test setup/cleanup and resource quotas.
  * Added timestamped test logging for clearer debug output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->