### PR TITLE
fix(RHOAIENG-37846): Allow oauth redirect in network policies

### DIFF
--- a/ray-operator/controllers/ray/networkpolicy_controller_unit_test.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller_unit_test.go
@@ -35,10 +35,9 @@ func setupNetworkPolicyTest(_ *testing.T) {
 	// Initialize NetworkPolicy controller with fake client (no DSCI by default)
 	scheme := runtime.NewScheme()
 	testNetworkPolicyController = &NetworkPolicyController{
-		Scheme: scheme,
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			Build(),
+		Scheme:     scheme,
+		Client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		RESTMapper: &stubRESTMapper{hasRouteAPI: false},
 	}
 
 	// Basic RayCluster without owner


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Gateway access rule to head NetworkPolicy configuration. Enables secure TCP traffic on port 8265 from pods in the configured gateway namespace (defaults to openshift-ingress on OpenShift clusters). Can be disabled by leaving the gateway namespace configuration empty. Existing monitoring rules remain unaffected. No other networking behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->