### PR TITLE
add resource grant and move httproute into prexisting namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/openshift/api v0.0.0-20250602203052-b29811a290c7 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -291,6 +291,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingressclasses

--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -282,17 +282,6 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - httproutes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
   - referencegrants
   verbs:
   - create

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -176,6 +176,9 @@ env:
 # If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job. Otherwise, only the RayCluster CR will be deleted. Default is false.
 # - name: DELETE_RAYJOB_CR_AFTER_JOB_FINISHES
 #   value: "false"
+# Gateway API configuration: Set the platform namespace for HTTPRoute creation and ReferenceGrant management
+# - name: APPLICATION_NAMESPACE
+#   value: "opendatahub"
 
 # -- Resource requests and limits for containers.
 resources:

--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberay-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kuberay-operator
+        env:
+        # Gateway API configuration for HTTPRoute placement
+        # APPLICATION_NAMESPACE determines where HTTPRoutes are created (platform namespace)
+        # Reuses the existing 'namespace' parameter from params.env
+        - name: APPLICATION_NAMESPACE
+          value: $(namespace)
+        # POD_NAMESPACE provides fallback namespace detection
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -44,3 +44,9 @@ patches:
     version: v1
     kind: Deployment
     name: kuberay-operator
+- path: gateway-env-patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: kuberay-operator

--- a/ray-operator/config/openshift/params.yaml
+++ b/ray-operator/config/openshift/params.yaml
@@ -13,3 +13,5 @@ varReference:
     kind: MutatingWebhookConfiguration
   - path: metadata/annotations/cert-manager.io~1inject-ca-from
     kind: ValidatingWebhookConfiguration
+  - path: spec/template/spec/containers[]/env[]/value
+    kind: Deployment

--- a/ray-operator/config/rbac/gateway-api-role.yaml
+++ b/ray-operator/config/rbac/gateway-api-role.yaml
@@ -24,3 +24,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -167,6 +167,7 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - httproutes
+  - referencegrants
   verbs:
   - create
   - delete

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -226,9 +226,12 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 		if err := r.Update(ctx, rayCluster); err != nil {
 			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
+		// Return early to allow the next reconciliation to create resources
+		// This follows the pattern used in raycluster_controller.go for finalizer handling
+		return nil
 	}
 
-	// Ensure OIDC resources exist
+	// Ensure OIDC resources exist (only after finalizer is present)
 	if err := r.ensureOIDCResources(ctx, rayCluster, authMode, logger); err != nil {
 		return fmt.Errorf("failed to ensure OIDC resources: %w", err)
 	}

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -16,6 +16,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -38,6 +40,9 @@ import (
 const (
 	// MediumRequeueDelay for ongoing rollouts
 	MediumRequeueDelay = 10 * time.Second
+
+	// Finalizer for ensuring cleanup of cross-namespace resources (HTTPRoutes)
+	authenticationFinalizer = "ray.io/authentication-resources"
 
 	// OAuth proxy constants
 	oauthProxyContainerName = "oauth-proxy"
@@ -57,20 +62,20 @@ const (
 // resources (ConfigMaps, ServiceAccounts, OpenShift Routes) and manages authentication configurations for Ray clusters on Openshift.
 type AuthenticationController struct {
 	client.Client
-	Recorder record.EventRecorder
-	// configClient configclient.Interface
-	Scheme *runtime.Scheme
-	// routeClient  *routev1client.RouteV1Client
-	options RayClusterReconcilerOptions
+	Recorder   record.EventRecorder
+	Scheme     *runtime.Scheme
+	RESTMapper meta.RESTMapper
+	options    RayClusterReconcilerOptions
 }
 
 // NewAuthenticationController creates a new authentication controller
 func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcilerOptions) *AuthenticationController {
 	return &AuthenticationController{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("authentication-controller"),
-		options:  options,
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		RESTMapper: mgr.GetRESTMapper(),
+		Recorder:   mgr.GetEventRecorderFor("authentication-controller"),
+		options:    options,
 	}
 }
 
@@ -92,7 +97,7 @@ func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcil
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch
-// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles authentication-related resources and manages OAuth sidecar injection
 func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -103,11 +108,21 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	rayCluster := &rayv1.RayCluster{}
 	if err := r.Get(ctx, req.NamespacedName, rayCluster); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info("RayCluster not found, likely deleted")
+			logger.Info("RayCluster not found, likely deleted - checking for orphaned resources")
+			// Clean up any orphaned ReferenceGrants in this namespace
+			if err := r.cleanupOrphanedReferenceGrant(ctx, req.Namespace, logger); err != nil {
+				logger.Info("Failed to cleanup orphaned ReferenceGrant (non-fatal)", "error", err)
+			}
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get RayCluster")
 		return ctrl.Result{RequeueAfter: MediumRequeueDelay}, err
+	}
+
+	// Handle deletion with finalizer
+	if !rayCluster.DeletionTimestamp.IsZero() {
+		logger.Info("RayCluster is being deleted, running finalizer", "cluster", rayCluster.Name)
+		return r.handleDeletion(ctx, rayCluster, logger)
 	}
 
 	// Skip if managed by external controller
@@ -143,6 +158,34 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
+// handleDeletion handles cleanup when a RayCluster is being deleted (finalizer pattern)
+func (r *AuthenticationController) handleDeletion(ctx context.Context, cluster *rayv1.RayCluster, logger logr.Logger) (ctrl.Result, error) {
+	// Check if our finalizer is present
+	if !controllerutil.ContainsFinalizer(cluster, authenticationFinalizer) {
+		logger.Info("Finalizer not present, skipping authentication cleanup")
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("Running authentication resource cleanup (finalizer)", "cluster", cluster.Name)
+
+	// Detect auth mode and run cleanup
+	authMode := utils.DetectAuthenticationMode(r.options.IsOpenShift)
+	if err := r.cleanupOIDCResources(ctx, cluster, authMode, logger); err != nil {
+		logger.Error(err, "Failed to cleanup authentication resources")
+		return ctrl.Result{RequeueAfter: MediumRequeueDelay}, err
+	}
+
+	// Remove the finalizer
+	controllerutil.RemoveFinalizer(cluster, authenticationFinalizer)
+	if err := r.Update(ctx, cluster); err != nil {
+		logger.Error(err, "Failed to remove finalizer")
+		return ctrl.Result{RequeueAfter: MediumRequeueDelay}, err
+	}
+
+	logger.Info("Authentication cleanup complete, finalizer removed", "cluster", cluster.Name)
+	return ctrl.Result{}, nil
+}
+
 // handleOIDCConfiguration configures OIDC for RayClusters (supports both OIDC and OAuth modes)
 func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, req ctrl.Request, authMode utils.AuthenticationMode, logger logr.Logger) error {
 	// Try to get RayCluster
@@ -156,12 +199,33 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 	shouldEnable := utils.ShouldEnableOIDC(rayCluster, authMode) || utils.ShouldEnableOAuth(rayCluster, authMode)
 	if !shouldEnable {
 		logger.Info("Authentication not requested for this cluster", "cluster", rayCluster.Name, "mode", authMode)
-		return r.cleanupOIDCResources(ctx, rayCluster, authMode, logger)
+
+		// Remove finalizer if present (auth is disabled)
+		if controllerutil.ContainsFinalizer(rayCluster, authenticationFinalizer) {
+			logger.Info("Removing authentication finalizer (auth disabled)", "cluster", rayCluster.Name)
+			if err := r.cleanupOIDCResources(ctx, rayCluster, authMode, logger); err != nil {
+				return err
+			}
+			controllerutil.RemoveFinalizer(rayCluster, authenticationFinalizer)
+			if err := r.Update(ctx, rayCluster); err != nil {
+				return fmt.Errorf("failed to remove finalizer: %w", err)
+			}
+		}
+		return nil
 	}
 
 	// Ensure ingress is enabled for httproute creation
 	if err := r.ensureIngressEnabled(ctx, rayCluster, logger); err != nil {
 		return fmt.Errorf("failed to ensure ingress enabled: %w", err)
+	}
+
+	// Add finalizer to ensure cleanup happens before cluster deletion
+	if !controllerutil.ContainsFinalizer(rayCluster, authenticationFinalizer) {
+		logger.Info("Adding authentication finalizer to RayCluster", "cluster", rayCluster.Name)
+		controllerutil.AddFinalizer(rayCluster, authenticationFinalizer)
+		if err := r.Update(ctx, rayCluster); err != nil {
+			return fmt.Errorf("failed to add finalizer: %w", err)
+		}
 	}
 
 	// Ensure OIDC resources exist
@@ -204,9 +268,22 @@ func (r *AuthenticationController) ensureOIDCResources(ctx context.Context, clus
 		return fmt.Errorf("failed to ensure service account: %w", err)
 	}
 
-	// Create HttpRoute
+	// Create ReferenceGrant BEFORE HTTPRoute to enable cross-namespace service references
+	if err := r.ensureReferenceGrant(ctx, cluster, logger); err != nil {
+		return fmt.Errorf("failed to ensure ReferenceGrant: %w", err)
+	}
+
+	// Create HttpRoute (in platform namespace)
 	if err := r.ensureHttpRoute(ctx, cluster, logger); err != nil {
 		return fmt.Errorf("failed to ensure HttpRoute: %w", err)
+	}
+
+	// MIGRATION: Clean up old HTTPRoute from cluster namespace if it exists
+	// This handles migration from the old implementation where HTTPRoutes were created in the cluster namespace
+	// We do this AFTER creating the new HTTPRoute to ensure no downtime
+	if err := r.cleanupOldHTTPRouteFromClusterNamespace(ctx, cluster, logger); err != nil {
+		logger.Info("Failed to cleanup old HTTPRoute (non-fatal)", "error", err)
+		// Don't fail reconciliation if old cleanup fails - it's a migration step
 	}
 
 	// Create ConfigMap
@@ -219,7 +296,52 @@ func (r *AuthenticationController) ensureOIDCResources(ctx context.Context, clus
 
 func (r *AuthenticationController) cleanupOIDCResources(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) error {
 	namer := utils.NewResourceNamer(cluster)
+	platformNamespace, _ := utils.GetPlatformNamespace(r.RESTMapper)
 
+	// STEP 1: Remove cross-namespace access FIRST (security-first approach)
+	// Delete ReferenceGrant if this is the last cluster with auth in the namespace
+	// This revokes cross-namespace trust before cleaning up other resources
+	if err := r.cleanupReferenceGrant(ctx, cluster, authMode, logger); err != nil {
+		logger.Info("Failed to cleanup ReferenceGrant", "error", err)
+	}
+
+	// STEP 2: Remove HTTPRoutes (both new and old locations)
+	// Remove HTTPRoute from platform namespace (using label selector)
+	httpRouteList := &gatewayv1.HTTPRouteList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(platformNamespace),
+		client.MatchingLabels{
+			"ray.io/cluster-namespace": cluster.Namespace,
+			"ray.io/cluster-name":      cluster.Name,
+		},
+	}
+
+	if err := r.List(ctx, httpRouteList, listOpts...); err == nil {
+		for i := range httpRouteList.Items {
+			httpRoute := &httpRouteList.Items[i]
+			if err := r.Delete(ctx, httpRoute); err != nil {
+				logger.Info("Failed to delete HTTPRoute", "error", err, "name", httpRoute.Name)
+			} else {
+				logger.Info("Deleted HTTPRoute", "name", httpRoute.Name, "namespace", platformNamespace)
+			}
+		}
+	} else {
+		logger.Info("Failed to list HTTPRoutes for cleanup", "error", err)
+	}
+
+	// MIGRATION: Also remove old HTTPRoute from cluster namespace (if it exists from previous implementation)
+	// Old implementation created HTTPRoute with name matching cluster name in the cluster's own namespace
+	oldHttpRoute := &gatewayv1.HTTPRoute{}
+	oldHttpRouteName := cluster.Name // Old naming convention
+	if err := r.Get(ctx, client.ObjectKey{Name: oldHttpRouteName, Namespace: cluster.Namespace}, oldHttpRoute); err == nil {
+		if err := r.Delete(ctx, oldHttpRoute); err != nil {
+			logger.Info("Failed to delete old HTTPRoute from cluster namespace", "error", err, "name", oldHttpRouteName)
+		} else {
+			logger.Info("Deleted old HTTPRoute from cluster namespace (migration)", "name", oldHttpRouteName, "namespace", cluster.Namespace)
+		}
+	}
+
+	// STEP 3: Remove namespace-scoped resources
 	// Remove ConfigMap
 	configMap := &corev1.ConfigMap{}
 	configMapName := namer.ConfigMapName()
@@ -228,17 +350,6 @@ func (r *AuthenticationController) cleanupOIDCResources(ctx context.Context, clu
 			logger.Info("Failed to delete ConfigMap", "error", err)
 		} else {
 			logger.Info("Deleted ConfigMap", "configMap", configMapName)
-		}
-	}
-
-	// Remove HTTPRoute
-	httpRoute := &gatewayv1.HTTPRoute{}
-	httpRouteName := cluster.Name
-	if err := r.Get(ctx, client.ObjectKey{Name: httpRouteName, Namespace: cluster.Namespace}, httpRoute); err == nil {
-		if err := r.Delete(ctx, httpRoute); err != nil {
-			logger.Info("Failed to delete HTTPRoute", "error", err)
-		} else {
-			logger.Info("Deleted HTTPRoute", "httpRoute", httpRouteName)
 		}
 	}
 
@@ -262,26 +373,46 @@ func (r *AuthenticationController) ensureHttpRoute(ctx context.Context, cluster 
 		return err
 	}
 
+	// Get platform namespace where HTTPRoute should be created
+	platformNamespace, _ := utils.GetPlatformNamespace(r.RESTMapper)
+	gatewayNamespace := utils.GetGatewayNamespace()
+	gatewayName := utils.GetGatewayName()
+
+	// HTTPRoute name includes namespace to avoid conflicts in platform namespace
+	// Must be a valid DNS label (max 63 characters) - use utility function for truncation
+	baseRouteName := fmt.Sprintf("%s-%s", cluster.Namespace, cluster.Name)
+	httpRouteName := utils.GenerateDNS1123Name(baseRouteName)
+
 	httpRoute := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name,
-			Namespace: cluster.Namespace,
+			Name:      httpRouteName,
+			Namespace: platformNamespace, // Create in platform namespace, not cluster namespace
+			Labels: map[string]string{
+				"ray.io/cluster-namespace": cluster.Namespace,
+				"ray.io/cluster-name":      cluster.Name,
+				utils.RayClusterLabelKey:   cluster.Name,
+			},
 		},
 	}
 
 	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, httpRoute, func() error {
-		// Set controller reference
-		if err := controllerutil.SetControllerReference(cluster, httpRoute, r.Scheme); err != nil {
-			return err
+		// NOTE: Cannot use SetControllerReference for cross-namespace ownership
+		// Instead, we use labels and finalizers for cleanup
+		// Add owner references in the same namespace if possible
+		if platformNamespace == cluster.Namespace {
+			if err := controllerutil.SetControllerReference(cluster, httpRoute, r.Scheme); err != nil {
+				return err
+			}
 		}
 
 		// Helper variables for pointer fields
 		group := gatewayv1.Group("gateway.networking.k8s.io")
 		kind := gatewayv1.Kind("Gateway")
-		gatewayName := gatewayv1.ObjectName("data-science-gateway")
-		namespace := gatewayv1.Namespace("openshift-ingress")
+		gatewayNameObj := gatewayv1.ObjectName(gatewayName)
+		gatewayNamespaceObj := gatewayv1.Namespace(gatewayNamespace)
 		serviceGroup := gatewayv1.Group("")
 		serviceKind := gatewayv1.Kind("Service")
+		serviceNamespace := gatewayv1.Namespace(cluster.Namespace) // Cross-namespace reference
 		weight := int32(1)
 		pathExact := gatewayv1.PathMatchExact
 		pathPrefix := gatewayv1.PathMatchPathPrefix
@@ -296,8 +427,8 @@ func (r *AuthenticationController) ensureHttpRoute(ctx context.Context, cluster 
 					{
 						Group:     &group,
 						Kind:      &kind,
-						Name:      gatewayName,
-						Namespace: &namespace,
+						Name:      gatewayNameObj,
+						Namespace: &gatewayNamespaceObj,
 					},
 				},
 			},
@@ -341,10 +472,11 @@ func (r *AuthenticationController) ensureHttpRoute(ctx context.Context, cluster 
 						{
 							BackendRef: gatewayv1.BackendRef{
 								BackendObjectReference: gatewayv1.BackendObjectReference{
-									Group: &serviceGroup,
-									Kind:  &serviceKind,
-									Name:  gatewayv1.ObjectName(serviceName),
-									Port:  &port,
+									Group:     &serviceGroup,
+									Kind:      &serviceKind,
+									Name:      gatewayv1.ObjectName(serviceName),
+									Namespace: &serviceNamespace, // Cross-namespace reference enabled by ReferenceGrant
+									Port:      &port,
 								},
 								Weight: &weight,
 							},
@@ -373,6 +505,198 @@ func (r *AuthenticationController) ensureHttpRoute(ctx context.Context, cluster 
 
 	if opResult != controllerutil.OperationResultNone {
 		logger.Info("HTTPRoute reconciled", "name", httpRoute.Name, "operation", opResult)
+	}
+
+	return nil
+}
+
+// cleanupOldHTTPRouteFromClusterNamespace removes HTTPRoutes that were created in the cluster namespace
+// by the old implementation. This is a migration helper that runs during reconciliation.
+func (r *AuthenticationController) cleanupOldHTTPRouteFromClusterNamespace(ctx context.Context, cluster *rayv1.RayCluster, logger logr.Logger) error {
+	// Old implementation created HTTPRoute with name matching cluster name in the cluster's own namespace
+	oldHttpRoute := &gatewayv1.HTTPRoute{}
+	oldHttpRouteName := cluster.Name // Old naming convention
+
+	err := r.Get(ctx, client.ObjectKey{Name: oldHttpRouteName, Namespace: cluster.Namespace}, oldHttpRoute)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// No old HTTPRoute to clean up - this is the normal case
+			logger.V(1).Info("No old HTTPRoute found in cluster namespace (already migrated or never existed)",
+				"name", oldHttpRouteName,
+				"namespace", cluster.Namespace)
+			return nil
+		}
+		return fmt.Errorf("failed to get old HTTPRoute: %w", err)
+	}
+
+	// Old HTTPRoute exists - delete it
+	logger.Info("Found old HTTPRoute in cluster namespace, deleting for migration",
+		"name", oldHttpRouteName,
+		"namespace", cluster.Namespace,
+		"hasOwnerRef", len(oldHttpRoute.OwnerReferences) > 0)
+
+	// Remove owner references if present (they might block deletion)
+	if len(oldHttpRoute.OwnerReferences) > 0 {
+		oldHttpRoute.OwnerReferences = nil
+		if err := r.Update(ctx, oldHttpRoute); err != nil {
+			logger.Info("Failed to remove owner references from old HTTPRoute", "error", err)
+			// Continue anyway - try to delete
+		}
+	}
+
+	if err := r.Delete(ctx, oldHttpRoute); err != nil {
+		if errors.IsNotFound(err) {
+			// Already deleted (race condition) - that's fine
+			return nil
+		}
+		return fmt.Errorf("failed to delete old HTTPRoute: %w", err)
+	}
+
+	logger.Info("Deleted old HTTPRoute from cluster namespace (migration complete)",
+		"name", oldHttpRouteName,
+		"namespace", cluster.Namespace)
+	r.Recorder.Event(cluster, "Normal", "HTTPRouteMigrated",
+		fmt.Sprintf("Migrated HTTPRoute from %s to platform namespace", cluster.Namespace))
+
+	return nil
+}
+
+// ensureReferenceGrant creates or updates a shared ReferenceGrant in the cluster's namespace.
+//
+// Design Decision: One Shared ReferenceGrant Per Namespace
+// This creates a single ReferenceGrant per namespace, shared by all RayClusters in that namespace.
+// The grant is only deleted when the last RayCluster with authentication is removed from the namespace.
+//
+// Why this approach:
+//   - Semantically correct: Trust relationship is between namespaces, not individual clusters
+//   - No resource redundancy: One grant regardless of cluster count
+//   - Cleaner resource model: Single grant represents namespace-level permission
+//   - Better UX: Users see one clear grant per namespace
+//   - Minimal API churn: Grant created once per namespace, not per cluster
+//
+// Implementation notes:
+//   - Uses consistent name: "kuberay-gateway-access"
+//   - No owner reference (shared across clusters)
+//   - Cleanup uses reference counting (see cleanupReferenceGrant)
+//   - Idempotent: Multiple clusters can safely call ensureReferenceGrant
+func (r *AuthenticationController) ensureReferenceGrant(ctx context.Context, cluster *rayv1.RayCluster, logger logr.Logger) error {
+	platformNamespace, _ := utils.GetPlatformNamespace(r.RESTMapper)
+
+	// Use a consistent name for the shared grant in this namespace
+	grantName := "kuberay-gateway-access"
+
+	referenceGrant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      grantName,
+			Namespace: cluster.Namespace, // Grant lives in the target namespace (where Services are)
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "kuberay-operator",
+				"app.kubernetes.io/component":  "gateway-access",
+			},
+		},
+	}
+
+	opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, referenceGrant, func() error {
+		// NOTE: Do NOT set controller reference - this grant is shared across multiple clusters
+		// Cleanup is handled by reference counting in cleanupReferenceGrant()
+
+		// Configure ReferenceGrant to allow HTTPRoutes from platform namespace to reference Services in this namespace
+		referenceGrant.Spec = gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{
+				{
+					Group:     gatewayv1.GroupName,
+					Kind:      "HTTPRoute",
+					Namespace: gatewayv1.Namespace(platformNamespace),
+				},
+			},
+			To: []gatewayv1beta1.ReferenceGrantTo{
+				{
+					Group: "", // Core API group for Services
+					Kind:  "Service",
+					// Name is optional - if omitted, allows all Services in this namespace
+					// We leave it unset to allow any RayCluster service in the namespace
+				},
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update ReferenceGrant: %w", err)
+	}
+
+	if opResult != controllerutil.OperationResultNone {
+		logger.Info("ReferenceGrant reconciled (shared)", "name", referenceGrant.Name, "namespace", cluster.Namespace, "operation", opResult)
+	}
+
+	return nil
+}
+
+// countClustersWithAuth counts RayClusters with authentication enabled in the namespace.
+// If excludeCluster is provided, it will be excluded from the count.
+func (r *AuthenticationController) countClustersWithAuth(ctx context.Context, namespace string, authMode utils.AuthenticationMode, excludeCluster *rayv1.RayCluster) (int, error) {
+	clusterList := &rayv1.RayClusterList{}
+	if err := r.List(ctx, clusterList, client.InNamespace(namespace)); err != nil {
+		return 0, fmt.Errorf("failed to list RayClusters: %w", err)
+	}
+
+	count := 0
+	for i := range clusterList.Items {
+		c := &clusterList.Items[i]
+		// Skip the excluded cluster if provided
+		if excludeCluster != nil && c.Name == excludeCluster.Name {
+			continue
+		}
+		// Check if this cluster has authentication enabled
+		if utils.ShouldEnableOIDC(c, authMode) || utils.ShouldEnableOAuth(c, authMode) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// cleanupReferenceGrant removes the shared ReferenceGrant only if this is the last RayCluster
+// with authentication in the namespace.
+func (r *AuthenticationController) cleanupReferenceGrant(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) error {
+	grantName := "kuberay-gateway-access"
+
+	// Count how many other RayClusters with authentication exist in this namespace
+	authClustersCount, err := r.countClustersWithAuth(ctx, cluster.Namespace, authMode, cluster)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("ReferenceGrant cleanup check",
+		"namespace", cluster.Namespace,
+		"otherAuthClusters", authClustersCount,
+		"action", func() string {
+			if authClustersCount == 0 {
+				return "will delete"
+			}
+			return "will retain"
+		}())
+
+	// Only delete the ReferenceGrant if this is the last cluster with auth
+	if authClustersCount == 0 {
+		grant := &gatewayv1beta1.ReferenceGrant{}
+		err := r.Get(ctx, client.ObjectKey{Name: grantName, Namespace: cluster.Namespace}, grant)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				logger.Info("ReferenceGrant already deleted", "name", grantName)
+				return nil
+			}
+			return fmt.Errorf("failed to get ReferenceGrant: %w", err)
+		}
+
+		if err := r.Delete(ctx, grant); err != nil {
+			return fmt.Errorf("failed to delete ReferenceGrant: %w", err)
+		}
+		logger.Info("Deleted shared ReferenceGrant (last cluster with auth)", "name", grantName, "namespace", cluster.Namespace)
+	} else {
+		logger.Info("ReferenceGrant retained (other clusters with auth exist)",
+			"name", grantName,
+			"namespace", cluster.Namespace,
+			"remainingClusters", authClustersCount)
 	}
 
 	return nil
@@ -643,6 +967,50 @@ func GetOIDCProxyVolumes(cluster *rayv1.RayCluster) []corev1.Volume {
 	return []corev1.Volume{
 		utils.CreateConfigMapVolume(configMapName, configMapName),
 	}
+}
+
+// cleanupOrphanedReferenceGrant checks if there are any RayClusters with auth in the namespace
+// and removes the ReferenceGrant if none exist. This handles cases where the controller is
+// triggered after a cluster is deleted.
+func (r *AuthenticationController) cleanupOrphanedReferenceGrant(ctx context.Context, namespace string, logger logr.Logger) error {
+	grantName := "kuberay-gateway-access"
+
+	// Count clusters with authentication enabled in the namespace
+	authMode := utils.DetectAuthenticationMode(r.options.IsOpenShift)
+	authClustersCount, err := r.countClustersWithAuth(ctx, namespace, authMode, nil)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Checking for orphaned ReferenceGrant",
+		"namespace", namespace,
+		"authClusters", authClustersCount)
+
+	// If no clusters with auth exist, delete the grant
+	if authClustersCount == 0 {
+		grant := &gatewayv1beta1.ReferenceGrant{}
+		err := r.Get(ctx, client.ObjectKey{Name: grantName, Namespace: namespace}, grant)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				logger.Info("No orphaned ReferenceGrant found", "namespace", namespace)
+				return nil
+			}
+			return fmt.Errorf("failed to get ReferenceGrant: %w", err)
+		}
+
+		if err := r.Delete(ctx, grant); err != nil {
+			return fmt.Errorf("failed to delete orphaned ReferenceGrant: %w", err)
+		}
+		logger.Info("Deleted orphaned ReferenceGrant (no clusters with auth remain)",
+			"name", grantName,
+			"namespace", namespace)
+	} else {
+		logger.Info("ReferenceGrant not orphaned (clusters with auth exist)",
+			"namespace", namespace,
+			"authClusters", authClustersCount)
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/ray-operator/controllers/ray/authentication_controller_gateway_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_gateway_test.go
@@ -174,7 +174,7 @@ func TestCleanupReferenceGrantWithMultipleClusters(t *testing.T) {
 			Name:      "cluster-1",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -184,7 +184,7 @@ func TestCleanupReferenceGrantWithMultipleClusters(t *testing.T) {
 			Name:      "cluster-2",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -224,6 +224,10 @@ func TestCleanupReferenceGrantWithMultipleClusters(t *testing.T) {
 		Namespace: "user-namespace",
 	}, rg)
 	require.NoError(t, err, "ReferenceGrant should still exist (cluster2 remains)")
+
+	// Actually delete cluster1 from the fake client to simulate real deletion
+	err = fakeClient.Delete(ctx, cluster1)
+	require.NoError(t, err, "Should delete cluster1 from fake client")
 
 	// Delete cluster2 - ReferenceGrant should be DELETED (last cluster)
 	err = controller.cleanupReferenceGrant(ctx, cluster2, utils.ModeOIDC, ctrl.Log)

--- a/ray-operator/controllers/ray/authentication_controller_gateway_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_gateway_test.go
@@ -1,0 +1,688 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ray
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+func TestEnsureReferenceGrant(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+			UID:       "test-uid",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Test: Create shared ReferenceGrant
+	err := controller.ensureReferenceGrant(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Should create ReferenceGrant without error")
+
+	// Verify ReferenceGrant was created with shared name
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access", // Shared name
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should exist")
+
+	// Verify ReferenceGrant spec
+	assert.Len(t, rg.Spec.From, 1, "Should have one From entry")
+	assert.Equal(t, gatewayv1.GroupName, string(rg.Spec.From[0].Group), "From group should be gateway.networking.k8s.io")
+	assert.Equal(t, "HTTPRoute", string(rg.Spec.From[0].Kind), "From kind should be HTTPRoute")
+	assert.Equal(t, "platform-namespace", string(rg.Spec.From[0].Namespace), "From namespace should be platform namespace")
+
+	assert.Len(t, rg.Spec.To, 1, "Should have one To entry")
+	assert.Equal(t, "", string(rg.Spec.To[0].Group), "To group should be empty (core API)")
+	assert.Equal(t, "Service", string(rg.Spec.To[0].Kind), "To kind should be Service")
+
+	// Verify NO owner reference (shared grant)
+	assert.Empty(t, rg.OwnerReferences, "Should have NO owner references (shared grant)")
+
+	// Verify labels
+	assert.Equal(t, "kuberay-operator", rg.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "gateway-access", rg.Labels["app.kubernetes.io/component"])
+
+	// Test: Update ReferenceGrant (should be idempotent)
+	err = controller.ensureReferenceGrant(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Should update ReferenceGrant without error")
+
+	// Verify it still exists with same spec
+	rg2 := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg2)
+	require.NoError(t, err, "ReferenceGrant should still exist")
+	assert.Equal(t, rg.Spec, rg2.Spec, "ReferenceGrant spec should be unchanged")
+}
+
+func TestSharedReferenceGrantMultipleClusters(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Create two clusters in the same namespace
+	cluster1 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "user-namespace",
+			UID:       "uid-1",
+		},
+	}
+
+	cluster2 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-2",
+			Namespace: "user-namespace",
+			UID:       "uid-2",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster1, cluster2).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Both clusters create the same ReferenceGrant
+	err := controller.ensureReferenceGrant(ctx, cluster1, ctrl.Log)
+	require.NoError(t, err, "Cluster 1 should create ReferenceGrant")
+
+	err = controller.ensureReferenceGrant(ctx, cluster2, ctrl.Log)
+	require.NoError(t, err, "Cluster 2 should create/update same ReferenceGrant")
+
+	// Verify only ONE ReferenceGrant exists
+	rgList := &gatewayv1beta1.ReferenceGrantList{}
+	err = fakeClient.List(ctx, rgList, client.InNamespace("user-namespace"))
+	require.NoError(t, err)
+	assert.Len(t, rgList.Items, 1, "Should have exactly ONE shared ReferenceGrant")
+	assert.Equal(t, "kuberay-gateway-access", rgList.Items[0].Name, "Should use shared name")
+}
+
+func TestCleanupReferenceGrantWithMultipleClusters(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Create two clusters with auth enabled
+	cluster1 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	cluster2 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-2",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	// Create the shared ReferenceGrant
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster1, cluster2, grant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Delete cluster1 - ReferenceGrant should be RETAINED (cluster2 still exists)
+	err := controller.cleanupReferenceGrant(ctx, cluster1, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant still exists
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should still exist (cluster2 remains)")
+
+	// Delete cluster2 - ReferenceGrant should be DELETED (last cluster)
+	err = controller.cleanupReferenceGrant(ctx, cluster2, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant is now deleted
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	assert.True(t, errors.IsNotFound(err), "ReferenceGrant should be deleted (last cluster removed)")
+}
+
+func TestEnsureHttpRouteInPlatformNamespace(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+	t.Setenv("GATEWAY_NAMESPACE", "openshift-ingress")
+	t.Setenv("GATEWAY_NAME", "data-science-gateway")
+
+	s := setupScheme()
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+			UID:       "test-uid",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "ray-head"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Test: Create HTTPRoute
+	err := controller.ensureHttpRoute(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Should create HTTPRoute without error")
+
+	// Verify HTTPRoute was created in platform namespace
+	httpRoute := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "user-namespace-test-cluster",
+		Namespace: "platform-namespace",
+	}, httpRoute)
+	require.NoError(t, err, "HTTPRoute should exist in platform namespace")
+
+	// Verify HTTPRoute labels
+	assert.Equal(t, "user-namespace", httpRoute.Labels["ray.io/cluster-namespace"], "Should have cluster-namespace label")
+	assert.Equal(t, "test-cluster", httpRoute.Labels["ray.io/cluster-name"], "Should have cluster-name label")
+	assert.Equal(t, "test-cluster", httpRoute.Labels[utils.RayClusterLabelKey], "Should have RayCluster label")
+
+	// Verify HTTPRoute parent refs
+	assert.Len(t, httpRoute.Spec.ParentRefs, 1, "Should have one parent ref")
+	assert.Equal(t, "data-science-gateway", string(httpRoute.Spec.ParentRefs[0].Name), "Parent should be data-science-gateway")
+	assert.Equal(t, "openshift-ingress", string(*httpRoute.Spec.ParentRefs[0].Namespace), "Parent namespace should be openshift-ingress")
+
+	// Verify HTTPRoute rules and backend refs
+	assert.NotEmpty(t, httpRoute.Spec.Rules, "Should have at least one rule")
+
+	// Find the rule with backend refs (skip redirect rule)
+	var ruleWithBackend *gatewayv1.HTTPRouteRule
+	for i := range httpRoute.Spec.Rules {
+		if len(httpRoute.Spec.Rules[i].BackendRefs) > 0 {
+			ruleWithBackend = &httpRoute.Spec.Rules[i]
+			break
+		}
+	}
+	require.NotNil(t, ruleWithBackend, "Should have a rule with backend refs")
+
+	backendRef := ruleWithBackend.BackendRefs[0]
+	assert.Equal(t, "test-cluster-head-svc", string(backendRef.Name), "Backend should reference head service")
+	assert.NotNil(t, backendRef.Namespace, "Backend should have namespace set")
+	assert.Equal(t, "user-namespace", string(*backendRef.Namespace), "Backend should reference user namespace")
+	assert.Equal(t, int32(8265), *backendRef.Port, "Backend should reference port 8265")
+}
+
+func TestCleanupOIDCResourcesWithCrossNamespace(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	namer := utils.NewResourceNamer(&rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	})
+
+	// Create resources to be cleaned up
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namer.ConfigMapName(),
+			Namespace: "user-namespace",
+		},
+	}
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-namespace-test-cluster",
+			Namespace: "platform-namespace", // HTTPRoute in platform namespace
+			Labels: map[string]string{
+				"ray.io/cluster-namespace": "user-namespace",
+				"ray.io/cluster-name":      "test-cluster",
+			},
+		},
+	}
+
+	// Shared ReferenceGrant (new naming)
+	referenceGrant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access", // Shared name
+			Namespace: "user-namespace",
+		},
+	}
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namer.ServiceAccountName(utils.ModeOIDC),
+			Namespace: "user-namespace",
+		},
+	}
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster, configMap, httpRoute, referenceGrant, serviceAccount).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+	}
+
+	// Execute cleanup (this is the last cluster, so ReferenceGrant should be deleted)
+	err := controller.cleanupOIDCResources(ctx, cluster, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ConfigMap is deleted
+	cm := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      namer.ConfigMapName(),
+		Namespace: "user-namespace",
+	}, cm)
+	assert.True(t, errors.IsNotFound(err), "ConfigMap should be deleted")
+
+	// Verify HTTPRoute is deleted from platform namespace
+	hr := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "user-namespace-test-cluster",
+		Namespace: "platform-namespace",
+	}, hr)
+	assert.True(t, errors.IsNotFound(err), "HTTPRoute should be deleted from platform namespace")
+
+	// Verify ReferenceGrant is deleted (last cluster)
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access", // Shared name
+		Namespace: "user-namespace",
+	}, rg)
+	assert.True(t, errors.IsNotFound(err), "ReferenceGrant should be deleted (last cluster)")
+
+	// Verify ServiceAccount is deleted
+	sa := &corev1.ServiceAccount{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      namer.ServiceAccountName(utils.ModeOIDC),
+		Namespace: "user-namespace",
+	}, sa)
+	assert.True(t, errors.IsNotFound(err), "ServiceAccount should be deleted")
+}
+
+func TestHTTPRouteNamingConflictPrevention(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Create two clusters with the same name in different namespaces
+	cluster1 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "namespace-a",
+			UID:       "uid-a",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "ray-head"}},
+					},
+				},
+			},
+		},
+	}
+
+	cluster2 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "namespace-b",
+			UID:       "uid-b",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "ray-head"}},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster1, cluster2).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Create HTTPRoutes for both clusters
+	err := controller.ensureHttpRoute(ctx, cluster1, ctrl.Log)
+	require.NoError(t, err, "Should create HTTPRoute for cluster1")
+
+	err = controller.ensureHttpRoute(ctx, cluster2, ctrl.Log)
+	require.NoError(t, err, "Should create HTTPRoute for cluster2")
+
+	// Verify both HTTPRoutes exist with different names
+	hr1 := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "namespace-a-my-cluster",
+		Namespace: "platform-namespace",
+	}, hr1)
+	require.NoError(t, err, "HTTPRoute for cluster1 should exist")
+
+	hr2 := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "namespace-b-my-cluster",
+		Namespace: "platform-namespace",
+	}, hr2)
+	require.NoError(t, err, "HTTPRoute for cluster2 should exist")
+
+	// Verify they have different labels
+	assert.Equal(t, "namespace-a", hr1.Labels["ray.io/cluster-namespace"])
+	assert.Equal(t, "namespace-b", hr2.Labels["ray.io/cluster-namespace"])
+}
+
+func TestEnsureOIDCResourcesCreatesReferenceGrantBeforeHTTPRoute(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+			UID:       "test-uid",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "ray-head"}},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Call ensureOIDCResources which should create both ReferenceGrant and HTTPRoute
+	err := controller.ensureOIDCResources(ctx, cluster, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Should ensure OIDC resources without error")
+
+	// Verify shared ReferenceGrant exists
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access", // Shared name
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should exist")
+
+	// Verify HTTPRoute exists
+	hr := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "user-namespace-test-cluster",
+		Namespace: "platform-namespace",
+	}, hr)
+	require.NoError(t, err, "HTTPRoute should exist")
+
+	// Verify ConfigMap exists
+	namer := utils.NewResourceNamer(cluster)
+	cm := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      namer.ConfigMapName(),
+		Namespace: "user-namespace",
+	}, cm)
+	require.NoError(t, err, "ConfigMap should exist")
+}
+
+func TestHTTPRouteNameDNSLabelLimit(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	tests := []struct {
+		name          string
+		clusterName   string
+		namespace     string
+		expectTrunc   bool
+		maxNameLength int
+	}{
+		{
+			name:          "Short name - no truncation",
+			clusterName:   "test-cluster",
+			namespace:     "default",
+			expectTrunc:   false,
+			maxNameLength: 63,
+		},
+		{
+			name:          "Long name - requires truncation",
+			clusterName:   "very-long-cluster-name-that-exceeds-the-kubernetes-dns-label-limit",
+			namespace:     "extremely-long-namespace-name-that-also-exceeds-limits",
+			expectTrunc:   true,
+			maxNameLength: 63,
+		},
+		{
+			name: "Edge case - exactly 63 characters",
+			// This creates a name that's exactly 63 chars: "namespace-name-" (15) + "cluster-name-that-is-exactly-48-chars-long" (48) = 63
+			clusterName:   "cluster-name-that-is-exactly-forty-eight-chars",
+			namespace:     "namespace-name",
+			expectTrunc:   false,
+			maxNameLength: 63,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.clusterName,
+					Namespace: tc.namespace,
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "ray-head"}},
+							},
+						},
+					},
+				},
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(cluster).
+				Build()
+
+			mapper := &mockRESTMapper{hasRouteAPI: true}
+			controller := &AuthenticationController{
+				Client:     fakeClient,
+				Scheme:     s,
+				RESTMapper: mapper,
+				Recorder:   record.NewFakeRecorder(10),
+				options: RayClusterReconcilerOptions{
+					IsOpenShift: true,
+				},
+			}
+
+			// Create HTTPRoute
+			err := controller.ensureHttpRoute(ctx, cluster, ctrl.Log)
+			require.NoError(t, err, "Should create HTTPRoute without error")
+
+			// Find the created HTTPRoute by labels (since name might be truncated)
+			httpRouteList := &gatewayv1.HTTPRouteList{}
+			err = fakeClient.List(ctx, httpRouteList,
+				client.InNamespace("platform-namespace"),
+				client.MatchingLabels{
+					"ray.io/cluster-namespace": tc.namespace,
+					"ray.io/cluster-name":      tc.clusterName,
+				})
+			require.NoError(t, err, "Should list HTTPRoutes")
+			require.Len(t, httpRouteList.Items, 1, "Should have exactly one HTTPRoute")
+
+			httpRoute := &httpRouteList.Items[0]
+
+			// Verify the name doesn't exceed DNS label limit
+			assert.LessOrEqual(t, len(httpRoute.Name), tc.maxNameLength,
+				"HTTPRoute name must not exceed %d characters (DNS label limit)", tc.maxNameLength)
+
+			// Verify labels are preserved (for cleanup via label selector)
+			assert.Equal(t, tc.namespace, httpRoute.Labels["ray.io/cluster-namespace"],
+				"Should have correct cluster-namespace label")
+			assert.Equal(t, tc.clusterName, httpRoute.Labels["ray.io/cluster-name"],
+				"Should have correct cluster-name label")
+
+			// If truncation is expected, verify the name is different from the simple concatenation
+			expectedSimpleName := tc.namespace + "-" + tc.clusterName
+			if tc.expectTrunc {
+				assert.NotEqual(t, expectedSimpleName, httpRoute.Name,
+					"Truncated name should differ from simple concatenation")
+				// Should contain a hash suffix
+				assert.Contains(t, httpRoute.Name, "-",
+					"Truncated name should contain hyphen before hash")
+			}
+		})
+	}
+}

--- a/ray-operator/controllers/ray/authentication_controller_integration_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_integration_test.go
@@ -1,0 +1,773 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ray
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+// TestEnsureIngressEnabled tests that ingress is automatically enabled when auth is configured
+func TestEnsureIngressEnabled(t *testing.T) {
+	ctx := context.Background()
+	s := setupScheme()
+
+	tests := []struct {
+		cluster         *rayv1.RayCluster
+		name            string
+		expectUpdate    bool
+		expectedIngress bool
+	}{
+		{
+			name: "Ingress not enabled - should enable",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						EnableIngress: nil, // Not set
+					},
+				},
+			},
+			expectUpdate:    true,
+			expectedIngress: true,
+		},
+		{
+			name: "Ingress explicitly disabled - should enable",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						EnableIngress: ptr.To(false),
+					},
+				},
+			},
+			expectUpdate:    true,
+			expectedIngress: true,
+		},
+		{
+			name: "Ingress already enabled - no update",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						EnableIngress: ptr.To(true),
+					},
+				},
+			},
+			expectUpdate:    false,
+			expectedIngress: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(tc.cluster).
+				Build()
+
+			controller := &AuthenticationController{
+				Client:   fakeClient,
+				Scheme:   s,
+				Recorder: record.NewFakeRecorder(10),
+				options: RayClusterReconcilerOptions{
+					IsOpenShift: true,
+				},
+			}
+
+			// Execute
+			err := controller.ensureIngressEnabled(ctx, tc.cluster, ctrl.Log)
+			require.NoError(t, err, "Should ensure ingress without error")
+
+			// Verify
+			updatedCluster := &rayv1.RayCluster{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      tc.cluster.Name,
+				Namespace: tc.cluster.Namespace,
+			}, updatedCluster)
+			require.NoError(t, err)
+
+			assert.NotNil(t, updatedCluster.Spec.HeadGroupSpec.EnableIngress,
+				"EnableIngress should be set")
+			assert.Equal(t, tc.expectedIngress, *updatedCluster.Spec.HeadGroupSpec.EnableIngress,
+				"EnableIngress should match expected value")
+		})
+	}
+}
+
+// TestHandleDeletion tests the finalizer-based deletion flow
+func TestHandleDeletion(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	namer := utils.NewResourceNamer(&rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	})
+
+	tests := []struct {
+		name              string
+		cluster           *rayv1.RayCluster
+		existingResources []client.Object
+		expectCleanup     bool
+	}{
+		{
+			name: "Cluster with finalizer and resources - should cleanup",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					Finalizers:        []string{authenticationFinalizer},
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Spec: rayv1.RayClusterSpec{
+					HeadGroupSpec: rayv1.HeadGroupSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "ray-head"}},
+							},
+						},
+					},
+				},
+			},
+			existingResources: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      namer.ConfigMapName(),
+						Namespace: "default",
+					},
+				},
+				&gatewayv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-test-cluster",
+						Namespace: "platform-namespace",
+						Labels: map[string]string{
+							"ray.io/cluster-namespace": "default",
+							"ray.io/cluster-name":      "test-cluster",
+						},
+					},
+				},
+				&gatewayv1beta1.ReferenceGrant{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kuberay-gateway-access",
+						Namespace: "default",
+					},
+				},
+			},
+			expectCleanup: true,
+		},
+		{
+			name: "Cluster without finalizer - should skip cleanup",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					Finalizers:        []string{"some-other-finalizer"}, // Has other finalizer but not auth finalizer
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+			},
+			existingResources: []client.Object{},
+			expectCleanup:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := []client.Object{tc.cluster}
+			objects = append(objects, tc.existingResources...)
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objects...).
+				Build()
+
+			mapper := &mockRESTMapper{hasRouteAPI: true}
+			controller := &AuthenticationController{
+				Client:     fakeClient,
+				Scheme:     s,
+				RESTMapper: mapper,
+				Recorder:   record.NewFakeRecorder(10),
+				options: RayClusterReconcilerOptions{
+					IsOpenShift: true,
+				},
+			}
+
+			// Execute
+			result, err := controller.handleDeletion(ctx, tc.cluster, ctrl.Log)
+			require.NoError(t, err, "Should handle deletion without error")
+			assert.Equal(t, ctrl.Result{}, result, "Should not requeue")
+
+			// Note: We cannot verify finalizer removal by getting the cluster from the fake client
+			// because once all finalizers are removed and deletionTimestamp is set,
+			// the fake client (correctly) deletes the object immediately, matching real Kubernetes behavior.
+			// The fact that handleDeletion succeeded without error confirms the finalizer was removed.
+		})
+	}
+}
+
+// TestCleanupOrphanedReferenceGrant tests cleanup of orphaned grants
+func TestCleanupOrphanedReferenceGrant(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	tests := []struct {
+		existingGrant    *gatewayv1beta1.ReferenceGrant
+		name             string
+		namespace        string
+		existingClusters []client.Object
+		expectDelete     bool
+	}{
+		{
+			name:      "No clusters with auth - should delete grant",
+			namespace: "default",
+			existingClusters: []client.Object{
+				&rayv1.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-no-auth",
+						Namespace: "default",
+						// No auth annotation
+					},
+				},
+			},
+			existingGrant: &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuberay-gateway-access",
+					Namespace: "default",
+				},
+			},
+			expectDelete: true,
+		},
+		{
+			name:      "Clusters with auth exist - should not delete",
+			namespace: "default",
+			existingClusters: []client.Object{
+				&rayv1.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-with-auth",
+						Namespace: "default",
+						Annotations: map[string]string{
+							utils.EnableSecureTrustedNetworkAnnotationKey: "true",
+						},
+					},
+				},
+			},
+			existingGrant: &gatewayv1beta1.ReferenceGrant{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kuberay-gateway-access",
+					Namespace: "default",
+				},
+			},
+			expectDelete: false,
+		},
+		{
+			name:             "No grant exists - should not error",
+			namespace:        "default",
+			existingClusters: []client.Object{},
+			existingGrant:    nil,
+			expectDelete:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := tc.existingClusters
+			if tc.existingGrant != nil {
+				objects = append(objects, tc.existingGrant)
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objects...).
+				Build()
+
+			mapper := &mockRESTMapper{hasRouteAPI: true}
+			controller := &AuthenticationController{
+				Client:     fakeClient,
+				Scheme:     s,
+				RESTMapper: mapper,
+				Recorder:   record.NewFakeRecorder(10),
+				options: RayClusterReconcilerOptions{
+					IsOpenShift: true,
+				},
+			}
+
+			// Execute
+			err := controller.cleanupOrphanedReferenceGrant(ctx, tc.namespace, ctrl.Log)
+			require.NoError(t, err, "Should cleanup without error")
+
+			// Verify
+			grant := &gatewayv1beta1.ReferenceGrant{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      "kuberay-gateway-access",
+				Namespace: tc.namespace,
+			}, grant)
+
+			if tc.expectDelete {
+				assert.True(t, errors.IsNotFound(err), "Grant should be deleted")
+			} else if tc.existingGrant != nil {
+				assert.NoError(t, err, "Grant should still exist")
+			}
+		})
+	}
+}
+
+// TestFullReconciliationLifecycle tests the complete lifecycle of a cluster with auth
+func TestFullReconciliationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+	t.Setenv("GATEWAY_NAMESPACE", "openshift-ingress")
+	t.Setenv("GATEWAY_NAME", "data-science-gateway")
+
+	s := setupScheme()
+
+	// Step 1: Create cluster with auth annotation
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+			Annotations: map[string]string{
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
+			},
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				EnableIngress: ptr.To(true), // Pre-enable ingress to avoid update conflicts
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "ray-head"}},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(100),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	namer := utils.NewResourceNamer(cluster)
+
+	t.Run("Step 1: Initial reconciliation creates all resources", func(t *testing.T) {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+
+		// Execute
+		result, err := controller.Reconcile(ctx, req)
+		require.NoError(t, err, "Should reconcile without error")
+		assert.Equal(t, ctrl.Result{}, result, "Should not requeue")
+
+		// Verify all resources created
+		// 1. Finalizer added
+		updatedCluster := &rayv1.RayCluster{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		}, updatedCluster)
+		require.NoError(t, err)
+		assert.Contains(t, updatedCluster.Finalizers, authenticationFinalizer,
+			"Finalizer should be added")
+
+		// 2. ServiceAccount created
+		sa := &corev1.ServiceAccount{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      namer.ServiceAccountName(utils.ModeOIDC),
+			Namespace: cluster.Namespace,
+		}, sa)
+		require.NoError(t, err, "ServiceAccount should be created")
+
+		// 3. ConfigMap created
+		cm := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      namer.ConfigMapName(),
+			Namespace: cluster.Namespace,
+		}, cm)
+		require.NoError(t, err, "ConfigMap should be created")
+		assert.Contains(t, cm.Data["config.yaml"], "test-cluster-head-svc",
+			"ConfigMap should contain service name")
+
+		// 4. ReferenceGrant created
+		grant := &gatewayv1beta1.ReferenceGrant{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      "kuberay-gateway-access",
+			Namespace: cluster.Namespace,
+		}, grant)
+		require.NoError(t, err, "ReferenceGrant should be created")
+
+		// 5. HTTPRoute created in platform namespace
+		httpRoute := &gatewayv1.HTTPRoute{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      "default-test-cluster",
+			Namespace: "platform-namespace",
+		}, httpRoute)
+		require.NoError(t, err, "HTTPRoute should be created")
+		assert.Equal(t, "default", httpRoute.Labels["ray.io/cluster-namespace"])
+		assert.Equal(t, "test-cluster", httpRoute.Labels["ray.io/cluster-name"])
+	})
+
+	t.Run("Step 2: Second reconciliation is idempotent", func(t *testing.T) {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+
+		// Execute again
+		result, err := controller.Reconcile(ctx, req)
+		require.NoError(t, err, "Should reconcile without error")
+		assert.Equal(t, ctrl.Result{}, result, "Should not requeue")
+
+		// Verify still only one of each resource
+		grantList := &gatewayv1beta1.ReferenceGrantList{}
+		err = fakeClient.List(ctx, grantList, client.InNamespace(cluster.Namespace))
+		require.NoError(t, err)
+		assert.Len(t, grantList.Items, 1, "Should have exactly one ReferenceGrant")
+
+		httpRouteList := &gatewayv1.HTTPRouteList{}
+		err = fakeClient.List(ctx, httpRouteList, client.InNamespace("platform-namespace"))
+		require.NoError(t, err)
+		assert.Len(t, httpRouteList.Items, 1, "Should have exactly one HTTPRoute")
+	})
+
+	t.Run("Step 3: Disabling auth removes resources", func(t *testing.T) {
+		// Update cluster to disable auth
+		updatedCluster := &rayv1.RayCluster{}
+		err := fakeClient.Get(ctx, types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		}, updatedCluster)
+		require.NoError(t, err)
+
+		// Remove auth annotation
+		delete(updatedCluster.Annotations, utils.EnableSecureTrustedNetworkAnnotationKey)
+		err = fakeClient.Update(ctx, updatedCluster)
+		require.NoError(t, err)
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      cluster.Name,
+				Namespace: cluster.Namespace,
+			},
+		}
+
+		// Execute
+		result, err := controller.Reconcile(ctx, req)
+		require.NoError(t, err, "Should reconcile without error")
+		assert.Equal(t, ctrl.Result{}, result, "Should not requeue")
+
+		// Verify resources cleaned up
+		finalCluster := &rayv1.RayCluster{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		}, finalCluster)
+		require.NoError(t, err)
+		assert.NotContains(t, finalCluster.Finalizers, authenticationFinalizer,
+			"Finalizer should be removed")
+
+		// Resources should be deleted
+		cm := &corev1.ConfigMap{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      namer.ConfigMapName(),
+			Namespace: cluster.Namespace,
+		}, cm)
+		assert.True(t, errors.IsNotFound(err), "ConfigMap should be deleted")
+
+		httpRoute := &gatewayv1.HTTPRoute{}
+		err = fakeClient.Get(ctx, types.NamespacedName{
+			Name:      "default-test-cluster",
+			Namespace: "platform-namespace",
+		}, httpRoute)
+		assert.True(t, errors.IsNotFound(err), "HTTPRoute should be deleted")
+	})
+}
+
+// TestHTTPRoutePathMatchingRules tests the complex redirect and rewrite rules
+func TestHTTPRoutePathMatchingRules(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "ray-head"}},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Create HTTPRoute
+	err := controller.ensureHttpRoute(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Should create HTTPRoute")
+
+	// Verify HTTPRoute structure
+	httpRoute := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "user-namespace-test-cluster",
+		Namespace: "platform-namespace",
+	}, httpRoute)
+	require.NoError(t, err, "HTTPRoute should exist")
+
+	// Verify we have 2 rules
+	require.Len(t, httpRoute.Spec.Rules, 2, "Should have 2 rules (redirect + rewrite)")
+
+	t.Run("Rule 0: Exact match redirect to #/", func(t *testing.T) {
+		rule := httpRoute.Spec.Rules[0]
+
+		// Verify match
+		require.Len(t, rule.Matches, 1, "Should have one match")
+		assert.Equal(t, gatewayv1.PathMatchExact, *rule.Matches[0].Path.Type,
+			"Should use exact path match")
+		assert.Equal(t, "/ray/user-namespace/test-cluster", *rule.Matches[0].Path.Value,
+			"Should match base path")
+
+		// Verify redirect filter
+		require.Len(t, rule.Filters, 1, "Should have one filter")
+		assert.Equal(t, gatewayv1.HTTPRouteFilterRequestRedirect, rule.Filters[0].Type,
+			"Should be redirect filter")
+		assert.NotNil(t, rule.Filters[0].RequestRedirect, "Redirect config should exist")
+		assert.Equal(t, "/ray/user-namespace/test-cluster/#/",
+			*rule.Filters[0].RequestRedirect.Path.ReplaceFullPath,
+			"Should redirect to /#/")
+		assert.Equal(t, 302, *rule.Filters[0].RequestRedirect.StatusCode,
+			"Should use 302 status code")
+
+		// Should NOT have backend refs (redirect only)
+		assert.Empty(t, rule.BackendRefs, "Redirect rule should not have backends")
+	})
+
+	t.Run("Rule 1: Prefix match with rewrite", func(t *testing.T) {
+		rule := httpRoute.Spec.Rules[1]
+
+		// Verify match
+		require.Len(t, rule.Matches, 1, "Should have one match")
+		assert.Equal(t, gatewayv1.PathMatchPathPrefix, *rule.Matches[0].Path.Type,
+			"Should use prefix path match")
+		assert.Equal(t, "/ray/user-namespace/test-cluster", *rule.Matches[0].Path.Value,
+			"Should match prefix")
+
+		// Verify backend refs
+		require.Len(t, rule.BackendRefs, 1, "Should have one backend")
+		backend := rule.BackendRefs[0]
+		assert.Equal(t, "test-cluster-head-svc", string(backend.Name),
+			"Should reference head service")
+		assert.Equal(t, "user-namespace", string(*backend.Namespace),
+			"Should reference user namespace")
+		assert.Equal(t, int32(8265), *backend.Port,
+			"Should reference port 8265")
+
+		// Verify rewrite filter
+		require.Len(t, rule.Filters, 1, "Should have one filter")
+		assert.Equal(t, gatewayv1.HTTPRouteFilterURLRewrite, rule.Filters[0].Type,
+			"Should be rewrite filter")
+		assert.NotNil(t, rule.Filters[0].URLRewrite, "Rewrite config should exist")
+		assert.Equal(t, gatewayv1.PrefixMatchHTTPPathModifier,
+			rule.Filters[0].URLRewrite.Path.Type,
+			"Should use prefix match rewrite")
+		assert.Equal(t, "/", *rule.Filters[0].URLRewrite.Path.ReplacePrefixMatch,
+			"Should rewrite to /")
+	})
+}
+
+// TestEnsureServiceAccountGeneric tests the generic service account creation for OIDC
+func TestEnsureServiceAccountGeneric(t *testing.T) {
+	ctx := context.Background()
+	s := setupScheme()
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		authMode   utils.AuthenticationMode
+		expectName string
+	}{
+		{
+			name:       "OIDC mode - creates OIDC service account",
+			authMode:   utils.ModeOIDC,
+			expectName: "test-cluster-oidc-sa",
+		},
+		{
+			name:       "OAuth mode - creates OAuth service account",
+			authMode:   utils.ModeIntegratedOAuth,
+			expectName: "test-cluster-oauth-proxy-sa",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(cluster).
+				Build()
+
+			controller := &AuthenticationController{
+				Client:   fakeClient,
+				Scheme:   s,
+				Recorder: record.NewFakeRecorder(10),
+				options: RayClusterReconcilerOptions{
+					IsOpenShift: true,
+				},
+			}
+
+			// Execute
+			err := controller.ensureServiceAccount(ctx, cluster, tc.authMode, ctrl.Log)
+			require.NoError(t, err, "Should create service account without error")
+
+			// Verify
+			sa := &corev1.ServiceAccount{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      tc.expectName,
+				Namespace: cluster.Namespace,
+			}, sa)
+			require.NoError(t, err, "Service account should exist")
+
+			// Verify owner reference
+			require.Len(t, sa.OwnerReferences, 1, "Should have one owner reference")
+			assert.Equal(t, cluster.Name, sa.OwnerReferences[0].Name,
+				"Should be owned by cluster")
+		})
+	}
+}
+
+// TestReconcileWithClusterNotFoundCleansUpOrphans tests orphan cleanup
+func TestReconcileWithClusterNotFoundCleansUpOrphans(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Create orphaned ReferenceGrant (no clusters)
+	orphanedGrant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(orphanedGrant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Reconcile non-existent cluster
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "non-existent",
+			Namespace: "default",
+		},
+	}
+
+	result, err := controller.Reconcile(ctx, req)
+	require.NoError(t, err, "Should not error when cluster not found")
+	assert.Equal(t, ctrl.Result{}, result, "Should not requeue")
+
+	// Verify orphaned grant is cleaned up
+	grant := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "default",
+	}, grant)
+	assert.True(t, errors.IsNotFound(err), "Orphaned grant should be deleted")
+}

--- a/ray-operator/controllers/ray/authentication_controller_shared_grant_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_shared_grant_test.go
@@ -1,0 +1,813 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ray
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+)
+
+// TestCleanupReferenceGrantWithMixedClusters tests that only clusters with auth are counted
+func TestCleanupReferenceGrantWithMixedClusters(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Cluster with auth enabled (OIDC)
+	clusterWithAuth := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-with-auth",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	// Cluster WITHOUT auth
+	clusterWithoutAuth := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-without-auth",
+			Namespace: "user-namespace",
+			// No auth annotation
+		},
+	}
+
+	// Another cluster being deleted (has auth)
+	clusterBeingDeleted := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-being-deleted",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	// Create the shared ReferenceGrant
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(clusterWithAuth, clusterWithoutAuth, clusterBeingDeleted, grant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Delete clusterBeingDeleted
+	// ReferenceGrant should be RETAINED because clusterWithAuth still exists
+	// clusterWithoutAuth should NOT be counted (no auth)
+	err := controller.cleanupReferenceGrant(ctx, clusterBeingDeleted, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant still exists
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should still exist (clusterWithAuth remains)")
+}
+
+// TestCleanupReferenceGrantNotFound tests that cleanup doesn't error if grant doesn't exist
+func TestCleanupReferenceGrantNotFound(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Try to cleanup when ReferenceGrant doesn't exist
+	// Should not error (last cluster case)
+	err := controller.cleanupReferenceGrant(ctx, cluster, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should not error when grant doesn't exist")
+}
+
+// TestCleanupReferenceGrantWithDifferentAuthModes tests OAuth and OIDC clusters both count
+func TestCleanupReferenceGrantWithDifferentAuthModes(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Cluster with OIDC auth
+	clusterOIDC := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-oidc",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	// Cluster with OAuth auth (different annotation but still auth)
+	clusterOAuth := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-oauth",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true", // Using same annotation for test
+			},
+		},
+	}
+
+	// Cluster being deleted (also has auth)
+	clusterBeingDeleted := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-deleted",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(clusterOIDC, clusterOAuth, clusterBeingDeleted, grant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Delete one cluster - both other auth-enabled clusters should be counted
+	err := controller.cleanupReferenceGrant(ctx, clusterBeingDeleted, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant still exists (2 auth clusters remain)
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should still exist (2 clusters with auth remain)")
+}
+
+// TestReferenceGrantIdempotency tests that multiple clusters can safely call ensureReferenceGrant
+func TestReferenceGrantIdempotency(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	cluster1 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "user-namespace",
+		},
+	}
+
+	cluster2 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-2",
+			Namespace: "user-namespace",
+		},
+	}
+
+	cluster3 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-3",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster1, cluster2, cluster3).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// All three clusters call ensureReferenceGrant
+	err := controller.ensureReferenceGrant(ctx, cluster1, ctrl.Log)
+	require.NoError(t, err, "First call should succeed")
+
+	err = controller.ensureReferenceGrant(ctx, cluster2, ctrl.Log)
+	require.NoError(t, err, "Second call should succeed")
+
+	err = controller.ensureReferenceGrant(ctx, cluster3, ctrl.Log)
+	require.NoError(t, err, "Third call should succeed")
+
+	// Verify exactly ONE grant exists
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	err = fakeClient.List(ctx, grantList, client.InNamespace("user-namespace"))
+	require.NoError(t, err, "List should succeed")
+
+	assert.Len(t, grantList.Items, 1, "Should have exactly ONE shared grant")
+	assert.Equal(t, "kuberay-gateway-access", grantList.Items[0].Name, "Grant should have shared name")
+}
+
+// TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters tests the counting logic
+func TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// 5 clusters total, but only 2 have auth enabled
+	clusters := []*rayv1.RayCluster{
+		// Auth enabled
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-1",
+				Namespace: "user-namespace",
+				Annotations: map[string]string{
+					"ray.io/enable-oidc": "true",
+				},
+			},
+		},
+		// Auth enabled
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-2",
+				Namespace: "user-namespace",
+				Annotations: map[string]string{
+					"ray.io/enable-oidc": "true",
+				},
+			},
+		},
+		// No auth
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-3",
+				Namespace: "user-namespace",
+			},
+		},
+		// Auth disabled
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-4",
+				Namespace: "user-namespace",
+				Annotations: map[string]string{
+					"ray.io/enable-oidc": "false",
+				},
+			},
+		},
+		// Being deleted (has auth)
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-5-deleted",
+				Namespace: "user-namespace",
+				Annotations: map[string]string{
+					"ray.io/enable-oidc": "true",
+				},
+			},
+		},
+	}
+
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	objects := []client.Object{grant}
+	for _, c := range clusters {
+		objects = append(objects, c)
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objects...).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Delete cluster-5-deleted
+	// Should count cluster-1 and cluster-2 (both have auth)
+	// Should NOT count cluster-3 and cluster-4 (no auth)
+	// Total auth clusters: 2, so grant should be RETAINED
+	err := controller.cleanupReferenceGrant(ctx, clusters[4], utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant still exists (2 auth-enabled clusters remain)
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should still exist (2 clusters with auth remain)")
+}
+
+// TestReferenceGrantDifferentNamespaces tests that grants are namespace-scoped
+func TestReferenceGrantDifferentNamespaces(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Cluster in namespace-a
+	clusterA := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-a",
+			Namespace: "namespace-a",
+		},
+	}
+
+	// Cluster in namespace-b
+	clusterB := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-b",
+			Namespace: "namespace-b",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(clusterA, clusterB).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Create grant in namespace-a
+	err := controller.ensureReferenceGrant(ctx, clusterA, ctrl.Log)
+	require.NoError(t, err, "Should create grant in namespace-a")
+
+	// Create grant in namespace-b
+	err = controller.ensureReferenceGrant(ctx, clusterB, ctrl.Log)
+	require.NoError(t, err, "Should create grant in namespace-b")
+
+	// Verify grant exists in namespace-a
+	rgA := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-a",
+	}, rgA)
+	require.NoError(t, err, "Grant should exist in namespace-a")
+
+	// Verify grant exists in namespace-b
+	rgB := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-b",
+	}, rgB)
+	require.NoError(t, err, "Grant should exist in namespace-b")
+
+	// Verify they're different resources
+	assert.Equal(t, "namespace-a", rgA.Namespace)
+	assert.Equal(t, "namespace-b", rgB.Namespace)
+}
+
+// TestCleanupReferenceGrantAllClustersWithoutAuth tests deletion when no auth clusters remain
+func TestCleanupReferenceGrantAllClustersWithoutAuth(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Cluster being deleted (has auth)
+	clusterWithAuth := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-with-auth",
+			Namespace: "user-namespace",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	// Other cluster WITHOUT auth
+	clusterWithoutAuth := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-without-auth",
+			Namespace: "user-namespace",
+			// No auth annotation
+		},
+	}
+
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(clusterWithAuth, clusterWithoutAuth, grant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Delete the cluster with auth
+	// clusterWithoutAuth should NOT be counted
+	// So grant should be DELETED (no auth clusters remain)
+	err := controller.cleanupReferenceGrant(ctx, clusterWithAuth, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify ReferenceGrant is deleted
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	assert.True(t, errors.IsNotFound(err), "ReferenceGrant should be deleted (no auth clusters remain)")
+}
+
+// TestEnsureReferenceGrantLabels tests that the grant has proper labels
+func TestEnsureReferenceGrantLabels(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Create ReferenceGrant
+	err := controller.ensureReferenceGrant(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Should create ReferenceGrant")
+
+	// Verify labels
+	rg := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "user-namespace",
+	}, rg)
+	require.NoError(t, err, "ReferenceGrant should exist")
+
+	assert.Equal(t, "kuberay-operator", rg.Labels["app.kubernetes.io/managed-by"],
+		"Should have managed-by label")
+	assert.Equal(t, "gateway-access", rg.Labels["app.kubernetes.io/component"],
+		"Should have component label")
+}
+
+// TestCleanupOldHTTPRouteFromClusterNamespace tests migration from old implementation
+func TestCleanupOldHTTPRouteFromClusterNamespace(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+	namer := utils.NewResourceNamer(&rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	})
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	}
+
+	// Old HTTPRoute in cluster namespace (from previous implementation)
+	oldHttpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",   // Old naming: just cluster name
+			Namespace: "user-namespace", // Old location: cluster namespace
+		},
+	}
+
+	// New HTTPRoute in platform namespace
+	newHttpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-namespace-test-cluster", // New naming
+			Namespace: "platform-namespace",          // New location
+			Labels: map[string]string{
+				"ray.io/cluster-namespace": "user-namespace",
+				"ray.io/cluster-name":      "test-cluster",
+			},
+		},
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namer.ConfigMapName(),
+			Namespace: "user-namespace",
+		},
+	}
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namer.ServiceAccountName(utils.ModeOIDC),
+			Namespace: "user-namespace",
+		},
+	}
+
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuberay-gateway-access",
+			Namespace: "user-namespace",
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster, oldHttpRoute, newHttpRoute, configMap, serviceAccount, grant).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Execute cleanup
+	err := controller.cleanupOIDCResources(ctx, cluster, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify old HTTPRoute in cluster namespace is deleted
+	oldHR := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "test-cluster",
+		Namespace: "user-namespace",
+	}, oldHR)
+	assert.True(t, errors.IsNotFound(err), "Old HTTPRoute in cluster namespace should be deleted (migration)")
+
+	// Verify new HTTPRoute in platform namespace is also deleted
+	newHR := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "user-namespace-test-cluster",
+		Namespace: "platform-namespace",
+	}, newHR)
+	assert.True(t, errors.IsNotFound(err), "New HTTPRoute in platform namespace should be deleted")
+}
+
+// TestCleanupOldHTTPRouteMigrationOnly tests migration when only old route exists
+func TestCleanupOldHTTPRouteMigrationOnly(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	cluster := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+		},
+	}
+
+	// Old HTTPRoute with owner references (from previous implementation)
+	oldHttpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "user-namespace",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "ray.io/v1",
+					Kind:       "RayCluster",
+					Name:       "test-cluster",
+					UID:        "test-uid",
+				},
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(cluster, oldHttpRoute).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Execute migration cleanup
+	err := controller.cleanupOldHTTPRouteFromClusterNamespace(ctx, cluster, ctrl.Log)
+	require.NoError(t, err, "Migration cleanup should succeed")
+
+	// Verify old HTTPRoute is deleted
+	oldHR := &gatewayv1.HTTPRoute{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "test-cluster",
+		Namespace: "user-namespace",
+	}, oldHR)
+	assert.True(t, errors.IsNotFound(err), "Old HTTPRoute should be deleted")
+}
+
+// TestMultipleNamespacesWithSharedGrants tests isolation between namespaces
+func TestMultipleNamespacesWithSharedGrants(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("APPLICATION_NAMESPACE", "platform-namespace")
+
+	s := setupScheme()
+
+	// Create clusters in different namespaces
+	clusterNs1 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "namespace-1",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	clusterNs2 := &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-2",
+			Namespace: "namespace-2",
+			Annotations: map[string]string{
+				"ray.io/enable-oidc": "true",
+			},
+		},
+	}
+
+	fakeClient := clientFake.NewClientBuilder().
+		WithScheme(s).
+		WithRuntimeObjects(clusterNs1, clusterNs2).
+		Build()
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	controller := &AuthenticationController{
+		Client:     fakeClient,
+		Scheme:     s,
+		RESTMapper: mapper,
+		Recorder:   record.NewFakeRecorder(10),
+		options: RayClusterReconcilerOptions{
+			IsOpenShift: true,
+		},
+	}
+
+	// Create grants in both namespaces
+	err := controller.ensureReferenceGrant(ctx, clusterNs1, ctrl.Log)
+	require.NoError(t, err, "Should create grant in namespace-1")
+
+	err = controller.ensureReferenceGrant(ctx, clusterNs2, ctrl.Log)
+	require.NoError(t, err, "Should create grant in namespace-2")
+
+	// Verify grants exist in both namespaces
+	grant1 := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-1",
+	}, grant1)
+	require.NoError(t, err, "Grant should exist in namespace-1")
+
+	grant2 := &gatewayv1beta1.ReferenceGrant{}
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-2",
+	}, grant2)
+	require.NoError(t, err, "Grant should exist in namespace-2")
+
+	// Delete cluster in namespace-1
+	err = controller.cleanupReferenceGrant(ctx, clusterNs1, utils.ModeOIDC, ctrl.Log)
+	require.NoError(t, err, "Cleanup should succeed")
+
+	// Verify grant in namespace-1 is deleted
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-1",
+	}, grant1)
+	assert.True(t, errors.IsNotFound(err), "Grant in namespace-1 should be deleted")
+
+	// Verify grant in namespace-2 still exists (isolation)
+	err = fakeClient.Get(ctx, types.NamespacedName{
+		Name:      "kuberay-gateway-access",
+		Namespace: "namespace-2",
+	}, grant2)
+	require.NoError(t, err, "Grant in namespace-2 should still exist (different namespace)")
+}

--- a/ray-operator/controllers/ray/authentication_controller_shared_grant_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_shared_grant_test.go
@@ -49,7 +49,7 @@ func TestCleanupReferenceGrantWithMixedClusters(t *testing.T) {
 			Name:      "cluster-with-auth",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -69,7 +69,7 @@ func TestCleanupReferenceGrantWithMixedClusters(t *testing.T) {
 			Name:      "cluster-being-deleted",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -162,7 +162,7 @@ func TestCleanupReferenceGrantWithDifferentAuthModes(t *testing.T) {
 			Name:      "cluster-oidc",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -173,7 +173,7 @@ func TestCleanupReferenceGrantWithDifferentAuthModes(t *testing.T) {
 			Name:      "cluster-oauth",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true", // Using same annotation for test
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true", // Using same annotation for test
 			},
 		},
 	}
@@ -184,7 +184,7 @@ func TestCleanupReferenceGrantWithDifferentAuthModes(t *testing.T) {
 			Name:      "cluster-deleted",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -303,7 +303,7 @@ func TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters(t *testing.T) {
 				Name:      "cluster-1",
 				Namespace: "user-namespace",
 				Annotations: map[string]string{
-					"ray.io/enable-oidc": "true",
+					utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 				},
 			},
 		},
@@ -313,7 +313,7 @@ func TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters(t *testing.T) {
 				Name:      "cluster-2",
 				Namespace: "user-namespace",
 				Annotations: map[string]string{
-					"ray.io/enable-oidc": "true",
+					utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 				},
 			},
 		},
@@ -330,7 +330,7 @@ func TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters(t *testing.T) {
 				Name:      "cluster-4",
 				Namespace: "user-namespace",
 				Annotations: map[string]string{
-					"ray.io/enable-oidc": "false",
+					utils.EnableSecureTrustedNetworkAnnotationKey: "false",
 				},
 			},
 		},
@@ -340,7 +340,7 @@ func TestCleanupReferenceGrantOnlyCountsAuthEnabledClusters(t *testing.T) {
 				Name:      "cluster-5-deleted",
 				Namespace: "user-namespace",
 				Annotations: map[string]string{
-					"ray.io/enable-oidc": "true",
+					utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 				},
 			},
 		},
@@ -471,7 +471,7 @@ func TestCleanupReferenceGrantAllClustersWithoutAuth(t *testing.T) {
 			Name:      "cluster-with-auth",
 			Namespace: "user-namespace",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -740,7 +740,7 @@ func TestMultipleNamespacesWithSharedGrants(t *testing.T) {
 			Name:      "cluster-1",
 			Namespace: "namespace-1",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}
@@ -750,7 +750,7 @@ func TestMultipleNamespacesWithSharedGrants(t *testing.T) {
 			Name:      "cluster-2",
 			Namespace: "namespace-2",
 			Annotations: map[string]string{
-				"ray.io/enable-oidc": "true",
+				utils.EnableSecureTrustedNetworkAnnotationKey: "true",
 			},
 		},
 	}

--- a/ray-operator/controllers/ray/utils/namespace.go
+++ b/ray-operator/controllers/ray/utils/namespace.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"os"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// GetPlatformNamespace returns the platform namespace where shared resources should be created.
+// This is used for placing HTTPRoutes and other resources that need to be in a trusted namespace.
+//
+// Returns: (namespace string, isOpenShift bool)
+//
+// Detection logic:
+// - OpenShift: APPLICATION_NAMESPACE (from ODH operator) → POD_NAMESPACE → ODH/RHODS fallback
+// - Non-OpenShift: POD_NAMESPACE → ray-system fallback
+func GetPlatformNamespace(restMapper meta.RESTMapper) (string, bool) {
+	isOpenShift := isOpenShiftCluster(restMapper)
+
+	// On OpenShift, use stricter namespace detection
+	if isOpenShift {
+		// 1. Check APPLICATION_NAMESPACE env var (set by ODH operator via params.env)
+		if appNs := os.Getenv("APPLICATION_NAMESPACE"); appNs != "" {
+			return appNs, true
+		}
+
+		// 2. Fallback to POD_NAMESPACE
+		if podNs := os.Getenv("POD_NAMESPACE"); podNs != "" {
+			return podNs, true
+		}
+
+		// 3. Final fallback for OpenShift (prefer redhat-ods-applications as primary)
+		return "redhat-ods-applications", true
+	}
+
+	// Non-OpenShift: simpler fallback chain
+	if podNs := os.Getenv("POD_NAMESPACE"); podNs != "" {
+		return podNs, false
+	}
+
+	return "ray-system", false
+}
+
+// isOpenShiftCluster checks if the cluster is running on OpenShift
+// by checking for the existence of the Route API
+func isOpenShiftCluster(restMapper meta.RESTMapper) bool {
+	if restMapper == nil {
+		return false
+	}
+	gvk := routev1.GroupVersion.WithKind("Route")
+	_, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	return err == nil
+}
+
+// GetGatewayNamespace returns the namespace where the Gateway resource is located.
+// In OpenShift AI/ODH environments, this is typically "openshift-ingress".
+func GetGatewayNamespace() string {
+	if gatewayNs := os.Getenv("GATEWAY_NAMESPACE"); gatewayNs != "" {
+		return gatewayNs
+	}
+	return "openshift-ingress"
+}
+
+// GetGatewayName returns the name of the Gateway resource to use.
+// In OpenShift AI/ODH environments, this is typically "data-science-gateway".
+func GetGatewayName() string {
+	if gatewayName := os.Getenv("GATEWAY_NAME"); gatewayName != "" {
+		return gatewayName
+	}
+	return "data-science-gateway"
+}

--- a/ray-operator/controllers/ray/utils/namespace_test.go
+++ b/ray-operator/controllers/ray/utils/namespace_test.go
@@ -1,0 +1,212 @@
+package utils
+
+import (
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// mockRESTMapper is a simple mock implementation of meta.RESTMapper for testing
+type mockRESTMapper struct {
+	hasRouteAPI bool
+}
+
+func (m *mockRESTMapper) KindFor(_ schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+
+func (m *mockRESTMapper) KindsFor(_ schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) ResourceFor(_ schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+
+func (m *mockRESTMapper) ResourcesFor(_ schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	if gk.Group == routev1.GroupVersion.Group && gk.Kind == "Route" && !m.hasRouteAPI {
+		return nil, &meta.NoKindMatchError{}
+	}
+	return &meta.RESTMapping{}, nil
+}
+
+func (m *mockRESTMapper) RESTMappings(_ schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	return nil, nil
+}
+
+func (m *mockRESTMapper) ResourceSingularizer(_ string) (singular string, err error) {
+	return "", nil
+}
+
+func TestGetPlatformNamespace_OpenShift_WithApplicationNamespace(t *testing.T) {
+	// Test with APPLICATION_NAMESPACE set (highest priority on OpenShift)
+	t.Setenv("APPLICATION_NAMESPACE", "custom-odh-namespace")
+	t.Setenv("POD_NAMESPACE", "should-not-use-this")
+
+	mapper := &mockRESTMapper{hasRouteAPI: true} // Simulate OpenShift
+	namespace, isOpenShift := GetPlatformNamespace(mapper)
+
+	assert.True(t, isOpenShift, "Should detect OpenShift")
+	assert.Equal(t, "custom-odh-namespace", namespace, "Should use APPLICATION_NAMESPACE")
+}
+
+func TestGetPlatformNamespace_OpenShift_WithPodNamespace(t *testing.T) {
+	// Test with only POD_NAMESPACE set (fallback on OpenShift)
+	t.Setenv("POD_NAMESPACE", "custom-pod-namespace")
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	namespace, isOpenShift := GetPlatformNamespace(mapper)
+
+	assert.True(t, isOpenShift, "Should detect OpenShift")
+	assert.Equal(t, "custom-pod-namespace", namespace, "Should use POD_NAMESPACE as fallback")
+}
+
+func TestGetPlatformNamespace_OpenShift_FallbackToDefault(t *testing.T) {
+	// Test with no env vars set (final fallback on OpenShift)
+	// (t.Setenv not called, both remain unset)
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	namespace, isOpenShift := GetPlatformNamespace(mapper)
+
+	assert.True(t, isOpenShift, "Should detect OpenShift")
+	assert.Equal(t, "redhat-ods-applications", namespace, "Should use default OpenShift namespace")
+}
+
+func TestGetPlatformNamespace_NonOpenShift_WithPodNamespace(t *testing.T) {
+	// Test non-OpenShift with POD_NAMESPACE set
+	t.Setenv("POD_NAMESPACE", "custom-namespace")
+
+	mapper := &mockRESTMapper{hasRouteAPI: false} // Simulate non-OpenShift
+	namespace, isOpenShift := GetPlatformNamespace(mapper)
+
+	assert.False(t, isOpenShift, "Should not detect OpenShift")
+	assert.Equal(t, "custom-namespace", namespace, "Should use POD_NAMESPACE")
+}
+
+func TestGetPlatformNamespace_NonOpenShift_FallbackToDefault(t *testing.T) {
+	// Test non-OpenShift with no env vars set
+	// (t.Setenv not called, both remain unset)
+
+	mapper := &mockRESTMapper{hasRouteAPI: false}
+	namespace, isOpenShift := GetPlatformNamespace(mapper)
+
+	assert.False(t, isOpenShift, "Should not detect OpenShift")
+	assert.Equal(t, "ray-system", namespace, "Should use default non-OpenShift namespace")
+}
+
+func TestGetPlatformNamespace_NilRESTMapper(t *testing.T) {
+	// Test with nil RESTMapper (should assume non-OpenShift)
+	t.Setenv("POD_NAMESPACE", "test-namespace")
+
+	namespace, isOpenShift := GetPlatformNamespace(nil)
+
+	assert.False(t, isOpenShift, "Should not detect OpenShift with nil mapper")
+	assert.Equal(t, "test-namespace", namespace, "Should use POD_NAMESPACE")
+}
+
+func TestGetGatewayNamespace_Default(t *testing.T) {
+	// Test with no env var set
+	// (t.Setenv not called, GATEWAY_NAMESPACE remains unset)
+
+	namespace := GetGatewayNamespace()
+	assert.Equal(t, "openshift-ingress", namespace, "Should return default gateway namespace")
+}
+
+func TestGetGatewayNamespace_CustomValue(t *testing.T) {
+	// Test with custom env var
+	t.Setenv("GATEWAY_NAMESPACE", "custom-gateway-namespace")
+
+	namespace := GetGatewayNamespace()
+	assert.Equal(t, "custom-gateway-namespace", namespace, "Should return custom gateway namespace")
+}
+
+func TestGetGatewayName_Default(t *testing.T) {
+	// Test with no env var set
+	// (t.Setenv not called, GATEWAY_NAME remains unset)
+
+	name := GetGatewayName()
+	assert.Equal(t, "data-science-gateway", name, "Should return default gateway name")
+}
+
+func TestGetGatewayName_CustomValue(t *testing.T) {
+	// Test with custom env var
+	t.Setenv("GATEWAY_NAME", "custom-gateway")
+
+	name := GetGatewayName()
+	assert.Equal(t, "custom-gateway", name, "Should return custom gateway name")
+}
+
+func TestIsOpenShiftCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		hasRouteAPI bool
+		expected    bool
+	}{
+		{
+			name:        "OpenShift cluster with Route API",
+			hasRouteAPI: true,
+			expected:    true,
+		},
+		{
+			name:        "Non-OpenShift cluster without Route API",
+			hasRouteAPI: false,
+			expected:    false,
+		},
+		{
+			name:        "Nil RESTMapper",
+			hasRouteAPI: false,
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mapper meta.RESTMapper
+			if tt.name != "Nil RESTMapper" {
+				mapper = &mockRESTMapper{hasRouteAPI: tt.hasRouteAPI}
+			}
+
+			result := isOpenShiftCluster(mapper)
+			assert.Equal(t, tt.expected, result, "OpenShift detection should match expected")
+		})
+	}
+}
+
+func TestEnvironmentVariablePriority(t *testing.T) {
+	// Test that APPLICATION_NAMESPACE takes priority over POD_NAMESPACE on OpenShift
+	t.Setenv("APPLICATION_NAMESPACE", "priority-namespace")
+	t.Setenv("POD_NAMESPACE", "fallback-namespace")
+
+	mapper := &mockRESTMapper{hasRouteAPI: true}
+	namespace, _ := GetPlatformNamespace(mapper)
+
+	assert.Equal(t, "priority-namespace", namespace,
+		"APPLICATION_NAMESPACE should take priority over POD_NAMESPACE on OpenShift")
+}
+
+func TestOpenShiftVsNonOpenShiftBehavior(t *testing.T) {
+	// Set both env vars
+	t.Setenv("APPLICATION_NAMESPACE", "openshift-app-ns")
+	t.Setenv("POD_NAMESPACE", "generic-pod-ns")
+
+	// Test OpenShift behavior - uses APPLICATION_NAMESPACE
+	openshiftMapper := &mockRESTMapper{hasRouteAPI: true}
+	openshiftNs, openshiftDetected := GetPlatformNamespace(openshiftMapper)
+
+	assert.True(t, openshiftDetected, "Should detect OpenShift")
+	assert.Equal(t, "openshift-app-ns", openshiftNs, "OpenShift should use APPLICATION_NAMESPACE")
+
+	// Test non-OpenShift behavior - uses POD_NAMESPACE (ignores APPLICATION_NAMESPACE)
+	nonOpenshiftMapper := &mockRESTMapper{hasRouteAPI: false}
+	nonOpenshiftNs, nonOpenshiftDetected := GetPlatformNamespace(nonOpenshiftMapper)
+
+	assert.False(t, nonOpenshiftDetected, "Should not detect OpenShift")
+	assert.Equal(t, "generic-pod-ns", nonOpenshiftNs, "Non-OpenShift should use POD_NAMESPACE")
+}

--- a/ray-operator/controllers/ray/utils/util.go
+++ b/ray-operator/controllers/ray/utils/util.go
@@ -3,7 +3,9 @@ package utils
 import (
 	"context"
 	"crypto/sha1" //nolint:gosec // We are not using this for security purposes
+	"crypto/sha256"
 	"encoding/base32"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"os"
@@ -18,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -324,6 +327,44 @@ func GenerateRayClusterName(serviceName string) string {
 // GenerateRayJobId generates a ray job id for submission
 func GenerateRayJobId(rayjob string) string {
 	return fmt.Sprintf("%s-%s", rayjob, rand.String(5))
+}
+
+// GenerateDNS1123Name generates a Kubernetes DNS1123-compliant name (max 63 characters).
+// If the input name exceeds the limit, it truncates and adds a deterministic hash suffix
+// to ensure uniqueness while maintaining DNS compliance.
+//
+// This is useful for resource names that combine multiple identifiers (e.g., namespace + cluster name)
+// that might exceed Kubernetes' DNS label limit.
+//
+// Example:
+//   - Short name: "default-my-cluster" → "default-my-cluster" (unchanged)
+//   - Long name: "very-long-namespace-very-long-cluster-name-that-exceeds-limit"
+//     → "very-long-cluster-name-that-exceed-a1b2c3d4e5" (truncated + hash)
+func GenerateDNS1123Name(baseName string) string {
+	const maxLen = validation.DNS1123LabelMaxLength // 63 characters
+
+	// If name fits, return as-is
+	if len(baseName) <= maxLen {
+		return baseName
+	}
+
+	// Name is too long - create a deterministic hash-based name
+	hash := sha256.Sum256([]byte(baseName))
+	suffix := hex.EncodeToString(hash[:])[:10] // Use first 10 chars of hash
+	maxPrefixLen := maxLen - len(suffix) - 1   // -1 for the hyphen
+
+	// Truncate the base name to fit
+	prefix := baseName
+	if len(prefix) > maxPrefixLen && maxPrefixLen > 0 {
+		prefix = strings.Trim(prefix[:maxPrefixLen], "-")
+	}
+
+	// Fallback to generic prefix if truncation resulted in empty string
+	if prefix == "" {
+		prefix = "resource"
+	}
+
+	return fmt.Sprintf("%s-%s", prefix, suffix)
 }
 
 // GenerateIdentifier generates identifier of same group pods

--- a/ray-operator/controllers/ray/utils/util_test.go
+++ b/ray-operator/controllers/ray/utils/util_test.go
@@ -1253,7 +1253,7 @@ func TestGenerateDNS1123Name(t *testing.T) {
 		},
 		{
 			name:        "64 characters - truncated with hash",
-			baseName:    "namespace-name-cluster-name-that-is-exactly-sixty-four-char",
+			baseName:    "namespace-name-cluster-name-that-is-exactly-sixty-four-charxxxxx", // 64 chars
 			expectTrunc: true,
 			expectLen:   63, // max length
 			// Prefix will be truncated and hash appended

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -30,6 +30,7 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configapi "github.com/ray-project/kuberay/ray-operator/apis/config/v1alpha1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -54,6 +55,7 @@ func init() {
 	utilruntime.Must(configapi.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.AddToScheme(scheme))
 	utilruntime.Must(gatewayv1.Install(scheme))
+	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Addresses 
https://issues.redhat.com/browse/RHOAIENG-38013

**Changes**
Create HTTPRoute in kuberay namespace rather than the raycluster namespaces
Create a ReferencGrant in the RayCluster Namespace.

**Verification**

Install Pre Change Version - including https://github.com/opendatahub-io/kuberay/pull/133
Create RayCluster. 
Verify that HttPRoute is in the RayCluster Namespace
Verify that the Route is accessible

Install this copy - including applying the new rbac permissions for resource grants

Verify 1 - that the http route of the existing cluster is moved to the kuberay namespace and that the reference grant is created and that the route is accessible 
Verify 2 - that only one reference grant is created when there are > 1 RayClusters in the same namespace
Verify 3 - that on new cluster the httproute is created in the kuberay namespace and that the reference grant is created and that the route is accessible
Verify 4 - that on cluster deletion the httproute from the kuberay namespace is deleted
Verify 5 - that the reference grant is only deleted when the last raycluster is removed from a user namespace. 



- [X] AI-driven


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-namespace Gateway support for Ray cluster authentication with automated migration, cleanup of ingress resources, and deterministic DNS-safe naming for routed resources.

* **Infrastructure & Configuration**
  * Added ReferenceGrant permissions for Gateway API, OpenShift-aware platform namespace selection with new env knobs, and Gateway API v1beta1 registration.

* **Tests**
  * Extensive unit and integration tests for ReferenceGrant/HTTPRoute lifecycle, namespace resolution, finalizers, migration, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->