### PR TITLE
test: move most of testing to post-merge on a bigger runner

### DIFF
--- a/.github/workflows/e2e-dispatch-to-bigger-runner.yml
+++ b/.github/workflows/e2e-dispatch-to-bigger-runner.yml
@@ -1,24 +1,22 @@
-name: Dispatch
+name: Dispatch E2E Tests
 on:
-  # currently disabled due to certain parts of upstream code not available in our midstream
-  # thus causing this workflow to fail
-  # push:
-  #   branches:
-  #   - dev
+  push:
+    branches:
+    - dev
   workflow_dispatch:
 
 jobs:
-  run-e2e-upgrade-on-bigger-runner:
+  run-e2e-on-bigger-runner:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Trigger kuberay upgrade job
+      - name: Trigger kuberay e2e tests job
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.KUBERAY_DISPATCH_TESTS }}
           repository: project-codeflare/kuberay-post-merge-tests
-          event-type: branch-dispatch
+          event-type: branch-dispatch-e2e-post-merge
 
       - name: Poll Project-Codeflare kuberay-post-merge-tests repo for workflow completion
         env:
@@ -31,7 +29,7 @@ jobs:
           echo "Polling $ORG/$REPO..."
 
           workflow_id=$(gh api repos/$ORG/$REPO/actions/workflows \
-            | jq -r '.workflows[] | select(.name=="Test KubeRay Operator Upgrade to latest available helm image") | .id')
+            | jq -r '.workflows[] | select(.name=="Test KubeRay Operator E2E Tests") | .id')
 
           if [ -z "$workflow_id" ]; then
             echo "❌ Workflow ID not found" && exit 1
@@ -61,7 +59,8 @@ jobs:
 
           echo "Monitoring run ID $run_id..."
 
-          for i in {1..90}; do
+          # Poll for up to ~2.5 hours (150 iterations * 60 seconds = 9000 seconds)
+          for i in {1..150}; do
             status=$(gh api repos/$ORG/$REPO/actions/runs/$run_id --jq '.status')
             conclusion=$(gh api repos/$ORG/$REPO/actions/runs/$run_id --jq '.conclusion')
 
@@ -69,16 +68,16 @@ jobs:
 
             if [[ "$status" == "completed" ]]; then
               if [[ "$conclusion" == "success" ]]; then
-                echo "✅ kuberay-post-merge-tests workflow completed successfully"
+                echo "✅ kuberay-post-merge-tests e2e workflow completed successfully"
                 exit 0
               else
-                echo "❌ kuberay-post-merge-tests workflow failed"
+                echo "❌ kuberay-post-merge-tests e2e workflow failed"
                 exit 1
               fi
             fi
 
-            sleep 10
+            sleep 60
           done
 
-          echo "❌ Timeout waiting for kuberay-post-merge-tests workflow"
+          echo "❌ Timeout waiting for kuberay-post-merge-tests e2e workflow"
           exit 1

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,13 +62,12 @@ jobs:
         - name: Run e2e tests
           if: steps.deploy.outcome == 'success'
           run: |
-            export KUBERAY_TEST_TIMEOUT_SHORT=5m
-            export KUBERAY_TEST_TIMEOUT_MEDIUM=12m
-            export KUBERAY_TEST_TIMEOUT_LONG=15m
+            export KUBERAY_TEST_TIMEOUT_SHORT=5m KUBERAY_TEST_TIMEOUT_MEDIUM=12m KUBERAY_TEST_TIMEOUT_LONG=15m KUBERAY_TEST_RAY_IMAGE=rayproject/ray:2.52.1
 
             set -euo pipefail
             cd ray-operator
-            go test -timeout 120m -v ./test/e2e -json 2>&1 | tee ./gotest.log | gotestfmt
+            # only test the subset of tests - the rest will be tested post-merge
+            go test -timeout 120m -p 1 -parallel 1 -v -run '^(TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$' ./test/e2e -json 2>&1 | tee ./gotest.log | gotestfmt
 
         - name: Print KubeRay operator logs
           if: steps.deploy.outcome == 'success'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

test: move most of testing to post-merge on a bigger runner (running [this workflow](https://github.com/project-codeflare/kuberay-post-merge-tests/blob/main/.github/workflows/kuberay-e2e-tests.yml))

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new E2E test dispatch workflow for external test repository integration with enhanced result monitoring.
  * Updated E2E test execution to run targeted test subsets with parallelism restrictions.
  * Changed E2E upgrade tests trigger from automatic to manual-only mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->