### PR TITLE
Fix: Eliminate ServiceAccount creation race condition with AuthenticationReady condition

### DIFF
--- a/ray-operator/apis/ray/v1/raycluster_types.go
+++ b/ray-operator/apis/ray/v1/raycluster_types.go
@@ -291,6 +291,9 @@ const (
 	RayClusterSuspending RayClusterConditionType = "RayClusterSuspending"
 	// RayClusterSuspended is set to true when all Pods belonging to a suspending RayCluster are deleted. Note that RayClusterSuspending and RayClusterSuspended cannot both be true at the same time.
 	RayClusterSuspended RayClusterConditionType = "RayClusterSuspended"
+	// AuthenticationReady indicates whether authentication resources (ServiceAccount, HTTPRoute, etc.) have been created by the AuthenticationController.
+	// This condition is set to True when authentication is successfully configured or when authentication is not enabled.
+	AuthenticationReady RayClusterConditionType = "AuthenticationReady"
 )
 
 // HeadInfo gives info about head

--- a/ray-operator/controllers/ray/authentication_controller_integration_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_integration_test.go
@@ -292,6 +292,7 @@ func TestFullReconciliationLifecycle(t *testing.T) {
 	fakeClient := clientFake.NewClientBuilder().
 		WithScheme(s).
 		WithObjects(cluster).
+		WithStatusSubresource(&rayv1.RayCluster{}).
 		Build()
 
 	mapper := &mockRESTMapper{hasRouteAPI: true}

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -344,6 +344,7 @@ const (
 	FailedToCreateServiceAccount     K8sEventType = "FailedToCreateServiceAccount"
 	AutoscalerServiceAccountNotFound K8sEventType = "AutoscalerServiceAccountNotFound"
 	WaitingForServiceAccount         K8sEventType = "WaitingForServiceAccount"
+	WaitingForAuthentication         K8sEventType = "WaitingForAuthentication"
 
 	// Role event list
 	CreatedRole        K8sEventType = "CreatedRole"
@@ -352,4 +353,12 @@ const (
 	// RoleBinding list
 	CreatedRoleBinding        K8sEventType = "CreatedRoleBinding"
 	FailedToCreateRoleBinding K8sEventType = "FailedToCreateRoleBinding"
+)
+
+// Authentication condition reasons
+const (
+	AuthenticationResourcesCreated = "AuthenticationResourcesCreated"
+	AuthenticationDisabled         = "AuthenticationDisabled"
+	AuthenticationPending          = "AuthenticationPending"
+	AuthenticationFailed           = "AuthenticationFailed"
 )


### PR DESCRIPTION
## Problem

Intermittent race condition causing ServiceAccount creation failures (~1 in 5-7 attempts) when creating RayClusters with authentication enabled.

**Error:**
```
Waiting for ServiceAccount <service_account_name> to be created by AuthenticationController
```

**Root Cause:**  
AuthenticationController and RayClusterReconciler run concurrently. AuthenticationController uses a two-phase pattern (add finalizer → create resources), but RayClusterReconciler may try to create pods before the second phase completes.

## Proposed Solution

Add `AuthenticationReady` status condition for explicit coordination between controllers:

- AuthenticationController sets condition to `True` when resources are created (or auth is disabled)
- RayClusterReconciler waits for condition before creating pods
- Follows Kubernetes best practices (similar to `HeadPodReady` condition)
- Backward compatible via `RayClusterStatusConditions` feature gate (enabled by default)

## Changes

- **API**: Added `AuthenticationReady` condition type to RayCluster
- **AuthenticationController**: Sets condition based on resource creation status
- **RayClusterReconciler**: Checks condition before creating head pods (with legacy fallback)
- **Constants**: Added condition reasons and event types

## Testing

- ✅ Build succeeds
- ✅ All packages compile
- ✅ Unit tests pass
- ✅ Condition logic verified

## Observability

```bash
kubectl describe raycluster my-cluster
```

Shows authentication status:
```yaml
Status:
  Conditions:
    Type: AuthenticationReady
    Status: True
    Reason: AuthenticationResourcesCreated
```

## Related Issues

https://issues.redhat.com/browse/RHOAIENG-47650

---

Fixes intermittent failures in codeflare-sdk automated tests on RHOAI 3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication readiness condition to track authentication resource state.
  * Head Pod creation now waits for authentication readiness when the feature is enabled, with a legacy fallback if not.
  * New authentication event types: pending, created, disabled, failed.

* **Bug Fixes**
  * Improved status transitions and finalizer handling to reduce stale-state races during reconciliation.

* **Tests**
  * Integration tests updated to exercise status subresource interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->