### PR TITLE
Fix hardcoded svc names + move finalizers + NP naming functions

### DIFF
--- a/ray-operator/controllers/ray/networkpolicy_controller.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller.go
@@ -142,6 +142,14 @@ func (r *NetworkPolicyController) createOrUpdateNetworkPolicy(ctx context.Contex
 	return nil
 }
 
+func headNetworkPolicyName(clusterName string) string {
+	return fmt.Sprintf("%s-head", clusterName)
+}
+
+func workerNetworkPolicyName(clusterName string) string {
+	return fmt.Sprintf("%s-workers", clusterName)
+}
+
 // buildHeadNetworkPolicy creates a NetworkPolicy for Ray head pods
 func (r *NetworkPolicyController) buildHeadNetworkPolicy(instance *rayv1.RayCluster, mode string) *networkingv1.NetworkPolicy {
 	labels := map[string]string{
@@ -178,7 +186,7 @@ func (r *NetworkPolicyController) buildHeadNetworkPolicy(instance *rayv1.RayClus
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-head", instance.Name),
+			Name:      headNetworkPolicyName(instance.Name),
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -237,7 +245,7 @@ func (r *NetworkPolicyController) buildWorkerNetworkPolicy(instance *rayv1.RayCl
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-workers", instance.Name),
+			Name:      workerNetworkPolicyName(instance.Name),
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
@@ -387,7 +395,7 @@ func (r *NetworkPolicyController) cleanupNetworkPoliciesIfNeeded(ctx context.Con
 
 	// Try to delete head NetworkPolicy if it exists
 	headNetworkPolicy := &networkingv1.NetworkPolicy{}
-	headName := fmt.Sprintf("%s-head", instance.Name)
+	headName := headNetworkPolicyName(instance.Name)
 	headKey := client.ObjectKey{Namespace: instance.Namespace, Name: headName}
 
 	if err := r.Get(ctx, headKey, headNetworkPolicy); err == nil {
@@ -405,7 +413,7 @@ func (r *NetworkPolicyController) cleanupNetworkPoliciesIfNeeded(ctx context.Con
 
 	// Try to delete worker NetworkPolicy if it exists
 	workerNetworkPolicy := &networkingv1.NetworkPolicy{}
-	workerName := fmt.Sprintf("%s-workers", instance.Name)
+	workerName := workerNetworkPolicyName(instance.Name)
 	workerKey := client.ObjectKey{Namespace: instance.Namespace, Name: workerName}
 
 	if err := r.Get(ctx, workerKey, workerNetworkPolicy); err == nil {

--- a/ray-operator/controllers/ray/raycluster_mtls_controller.go
+++ b/ray-operator/controllers/ray/raycluster_mtls_controller.go
@@ -29,10 +29,6 @@ const (
 	// Requeue intervals aligned with ODH mTLS controller.
 	mtlsDefaultRequeueDuration = 30 * time.Second
 	mtlsPeriodicCheckDuration  = 1 * time.Minute
-
-	// mtlsFinalizer prevents the RayCluster from being deleted before the mTLS
-	// controller has cleaned up auto-generated cert-manager secrets.
-	mtlsFinalizer = "ray.io/mtls-cleanup"
 )
 
 // RayClusterMTLSController manages mTLS certificates for RayClusters using cert-manager.
@@ -82,7 +78,7 @@ func (r *RayClusterMTLSController) Reconcile(ctx context.Context, req ctrl.Reque
 	// Without handling deletion before the TLS check, the finalizer would
 	// never be removed and the RayCluster would be stuck in Terminating.
 	if instance.DeletionTimestamp != nil && !instance.DeletionTimestamp.IsZero() {
-		if controllerutil.ContainsFinalizer(instance, mtlsFinalizer) {
+		if controllerutil.ContainsFinalizer(instance, utils.MTLSCleanupFinalizer) {
 			// Only delete secrets in auto-generate mode; BYOC secrets belong to the user.
 			if !utils.IsTLSBYOC(&instance.Spec) {
 				if err := r.deleteTLSSecrets(ctx, instance); err != nil {
@@ -95,7 +91,7 @@ func (r *RayClusterMTLSController) Reconcile(ctx context.Context, req ctrl.Reque
 					"Auto-generated mTLS secrets deleted")
 			}
 			// Remove the finalizer to unblock deletion.
-			controllerutil.RemoveFinalizer(instance, mtlsFinalizer)
+			controllerutil.RemoveFinalizer(instance, utils.MTLSCleanupFinalizer)
 			if err := r.Update(ctx, instance); err != nil {
 				logger.Error(err, "Failed to remove mTLS finalizer")
 				return ctrl.Result{}, err
@@ -113,8 +109,8 @@ func (r *RayClusterMTLSController) Reconcile(ctx context.Context, req ctrl.Reque
 	// Ensure the finalizer is present so we get a chance to clean up secrets before deletion.
 	// Only needed for auto-generate mode; BYOC secrets are user-managed and never deleted.
 	if !utils.IsTLSBYOC(&instance.Spec) {
-		if !controllerutil.ContainsFinalizer(instance, mtlsFinalizer) {
-			controllerutil.AddFinalizer(instance, mtlsFinalizer)
+		if !controllerutil.ContainsFinalizer(instance, utils.MTLSCleanupFinalizer) {
+			controllerutil.AddFinalizer(instance, utils.MTLSCleanupFinalizer)
 			if err := r.Update(ctx, instance); err != nil {
 				logger.Error(err, "Failed to add mTLS finalizer")
 				return ctrl.Result{}, err
@@ -393,7 +389,10 @@ func (r *RayClusterMTLSController) reconcileCAIssuer(ctx context.Context, instan
 func (r *RayClusterMTLSController) reconcileHeadCertificate(ctx context.Context, instance *rayv1.RayCluster) error {
 	certName := fmt.Sprintf("%s-%s", utils.RayHeadCertPrefix, instance.Name)
 	secretName := fmt.Sprintf("%s-%s", utils.RayHeadSecretPrefix, instance.Name)
-	headSvcName := fmt.Sprintf("%s-head-svc", instance.Name)
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, instance.Spec, instance.Name)
+	if err != nil {
+		return err
+	}
 
 	podIPs, err := r.getPodIPs(ctx, instance)
 	if err != nil {
@@ -410,6 +409,11 @@ func (r *RayClusterMTLSController) reconcileHeadCertificate(ctx context.Context,
 	sort.Strings(desiredDNSNames)
 	desiredIPAddresses := normalizeIPs(podIPs)
 
+	// Known limitation: Ray reads TLS files once at startup and does not hot-reload them.
+	// When cert-manager renews this certificate (updating the Secret), running Ray pods
+	// will continue using the old certificate until restarted. The RenewBefore window
+	// (15 days before the 90-day expiry) provides time for a rolling restart, but no
+	// automatic restart mechanism is currently implemented.
 	desiredSpec := certmanagerv1.CertificateSpec{
 		SecretName:  secretName,
 		Duration:    &metav1.Duration{Duration: 2160 * time.Hour},
@@ -472,8 +476,9 @@ func (r *RayClusterMTLSController) reconcileWorkerCertificate(ctx context.Contex
 	}
 
 	// Build DNS names including per-worker-group service names and wildcards
-	// for dynamic worker discovery (aligned with ODH mTLS controller).
-	workerSvcName := fmt.Sprintf("%s-worker-svc", instance.Name)
+	// for dynamic worker discovery. Uses the headless service name ({cluster}-headless)
+	// which is the actual worker service created by KubeRay.
+	workerSvcName := fmt.Sprintf("%s-%s", instance.Name, utils.HeadlessServiceSuffix)
 	dnsNames := []string{
 		workerSvcName,
 		"localhost",
@@ -501,6 +506,8 @@ func (r *RayClusterMTLSController) reconcileWorkerCertificate(ctx context.Contex
 	sort.Strings(desiredDNSNames)
 	desiredIPAddresses := normalizeIPs(podIPs)
 
+	// Known limitation: Ray reads TLS files once at startup and does not hot-reload them.
+	// See the equivalent comment in reconcileHeadCertificate for details.
 	desiredSpec := certmanagerv1.CertificateSpec{
 		SecretName:  secretName,
 		Duration:    &metav1.Duration{Duration: 2160 * time.Hour},
@@ -718,8 +725,9 @@ func uniqueStrings(values []string) []string {
 // tlsResourceLabels returns standard labels for cert-manager resources owned by a RayCluster.
 func tlsResourceLabels(clusterName, component string) map[string]string {
 	return map[string]string{
-		"app.kubernetes.io/name":      "ray-tls",
-		"app.kubernetes.io/component": component,
-		utils.RayClusterLabelKey:      clusterName,
+		utils.KubernetesApplicationNameLabelKey: utils.ApplicationName,
+		utils.KubernetesCreatedByLabelKey:       utils.ComponentName,
+		"app.kubernetes.io/component":           component,
+		utils.RayClusterLabelKey:                clusterName,
 	}
 }

--- a/ray-operator/controllers/ray/raycluster_mtls_controller_test.go
+++ b/ray-operator/controllers/ray/raycluster_mtls_controller_test.go
@@ -186,8 +186,10 @@ func TestMTLSController_AutoGenerate_CreatesFullPKI(t *testing.T) {
 		Namespace: "default",
 	}, headCert)
 	require.NoError(t, err, "head certificate should be created")
+	headSvcName, err := utils.GenerateHeadServiceName(utils.RayClusterCRD, cluster.Spec, cluster.Name)
+	require.NoError(t, err)
 	assert.Contains(t, headCert.Spec.DNSNames, "localhost")
-	assert.Contains(t, headCert.Spec.DNSNames, fmt.Sprintf("%s-head-svc", cluster.Name))
+	assert.Contains(t, headCert.Spec.DNSNames, headSvcName)
 	assert.Contains(t, headCert.Spec.IPAddresses, "127.0.0.1")
 
 	// Verify worker certificate was created with correct DNS names.
@@ -376,7 +378,7 @@ func TestMTLSController_WorkerCertHasWildcardDNS(t *testing.T) {
 	}, workerCert)
 	require.NoError(t, err)
 
-	workerSvcName := fmt.Sprintf("%s-worker-svc", cluster.Name)
+	workerSvcName := fmt.Sprintf("%s-%s", cluster.Name, utils.HeadlessServiceSuffix)
 	assert.Contains(t, workerCert.Spec.DNSNames, workerSvcName)
 	assert.Contains(t, workerCert.Spec.DNSNames,
 		fmt.Sprintf("*.%s.%s.svc", workerSvcName, cluster.Namespace))
@@ -594,7 +596,7 @@ func TestMTLSController_DeletionWithDisabledMTLS_RemovesFinalizer(t *testing.T) 
 	// mTLS was previously enabled (finalizer present) but user disabled it before deleting.
 	cluster.Spec.TLSOptions = nil
 	cluster.DeletionTimestamp = &now
-	cluster.Finalizers = []string{mtlsFinalizer}
+	cluster.Finalizers = []string{utils.MTLSCleanupFinalizer}
 
 	r := newMTLSController(t, cluster)
 	ctx := context.Background()
@@ -618,7 +620,7 @@ func TestMTLSController_AutoGenerate_DeletionCleansUpSecrets(t *testing.T) {
 	cluster.Spec.TLSOptions = &rayv1.TLSOptions{}
 	cluster.DeletionTimestamp = &now
 	// Simulate that the finalizer was previously added during normal reconciliation.
-	cluster.Finalizers = []string{mtlsFinalizer}
+	cluster.Finalizers = []string{utils.MTLSCleanupFinalizer}
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: utils.GetCASecretName(cluster.Name, cluster.UID), Namespace: "default"},
@@ -691,6 +693,16 @@ func TestCertificateNeedsUpdate(t *testing.T) {
 		IPAddresses: []string{"10.0.0.1", "10.0.0.2"},
 	}
 	assert.True(t, certificateNeedsUpdate(existing, desired2), "different DNS names should need update")
+
+	existing3 := &certmanagerv1.CertificateSpec{
+		DNSNames:    []string{"a.svc"},
+		IPAddresses: []string{"127.0.0.1"},
+	}
+	desired3 := &certmanagerv1.CertificateSpec{
+		DNSNames:    []string{"a.svc"},
+		IPAddresses: []string{"127.0.0.1", "10.0.0.1"},
+	}
+	assert.True(t, certificateNeedsUpdate(existing3, desired3), "different IP addresses should need update")
 }
 
 // --- checkMTLSSecretsReady tests (in main reconciler) ---

--- a/ray-operator/controllers/ray/utils/constant.go
+++ b/ray-operator/controllers/ray/utils/constant.go
@@ -278,6 +278,10 @@ const (
 	// Finalizers for RayJob
 	RayJobStopJobFinalizer = "ray.io/rayjob-finalizer"
 
+	// MTLSCleanupFinalizer prevents the RayCluster from being deleted before the mTLS
+	// controller has cleaned up auto-generated cert-manager secrets.
+	MTLSCleanupFinalizer = "ray.io/mtls-cleanup"
+
 	// RayNodeHeadGroupLabelValue is the value for the RayNodeGroupLabelKey label on a head node
 	RayNodeHeadGroupLabelValue      = "headgroup"
 	RayNodeSubmitterGroupLabelValue = "submittergroup"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Addressed review feedback re:

* encapsulating networkPolicy naming into functions for re-use.
* moved finalizers to utils
* per cursor bot suggestion, removed hard-coding of svc names

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(
