### PR TITLE
test: remove sanity test level

### DIFF
--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -16,14 +16,11 @@ EXTRA_ARGS=()
 show_usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
-    echo "  -testTier=VALUE    Specify test tier (Sanity, Tier1, or Sanity,Tier1)"
+    echo "  -testTier=VALUE    Specify test tier (only Tier1 is supported)"
     echo "  -h, -help          Show this help message"
     echo ""
     echo "Examples:"
-    echo "  $0 -testTier=Sanity"
     echo "  $0 -testTier=Tier1"
-    echo "  $0 -testTier=Sanity,Tier1"
-    echo "  $0 -testTier=\"Sanity Tier1\""
     exit 0
 }
 
@@ -58,17 +55,15 @@ fi
 TEST_RUN_REGEX=""
 
 # Handle different combinations of test tags
-if [[ "$TEST_TAGS" == *"Sanity"* && "$TEST_TAGS" == *"Tier1"* ]]; then
-    echo "Running Sanity and Tier1 kuberay e2e tests"
+if [[ "$TEST_TAGS" == *"Tier1"* ]]; then
+    echo "Running Tier1 kuberay e2e tests"
     TEST_RUN_REGEX="^(TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$"
 elif [[ "$TEST_TAGS" == *"Sanity"* ]]; then
-    echo "Running Sanity kuberay e2e tests"
-    TEST_RUN_REGEX="^TestRayJobWithClusterSelector$"
-elif [[ "$TEST_TAGS" == *"Tier1"* ]]; then
-    echo "Running Tier1 kuberay tests"
-    TEST_RUN_REGEX="^(TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$"
+    echo "Warning: 'Sanity' tier is no longer supported. Only 'Tier1' is supported."
+    echo ""
+    show_usage
 else
-    echo "Info: Invalid test tier '$TEST_TAGS'. Valid options are: Sanity, Tier1, or both (Sanity,Tier1 or 'Sanity Tier1')"
+    echo "Info: Invalid test tier '$TEST_TAGS'. Only 'Tier1' is supported."
     echo ""
     show_usage
 fi


### PR DESCRIPTION
## Why are these changes needed?

test: remove sanity test level

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-56168

## Verification

### sanity
```
podman run --rm -it --pull "never" --platform linux/amd64 \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Sanity      
Warning: 'Sanity' tier is no longer supported. Only 'Tier1' is supported.

Usage: run-tests.sh [OPTIONS]
Options:
  -testTier=VALUE    Specify test tier (only Tier1 is supported)
  -h, -help          Show this help message

Examples:
  run-tests.sh -testTier=Tier1
```

### tier1
```
podman run --rm -it --pull "never" --platform linux/amd64 \
  -v ~/.kube/config:/kuberay/tests/.kube/config:ro \
  -v ./results:/kuberay/tests/results:Z \
  quay.io/opendatahub/kuberay-tests:latest -- -testTier=Tier1 
Running Tier1 kuberay e2e tests
=== RUN   TestRayJobWithClusterSelector
    rayjob_cluster_selector_test.go:27: [2026-04-28T08:28:12Z] Created ConfigMap test-ns-bkv54/jobs successfully
    rayjob_cluster_selector_test.go:35: [2026-04-28T08:28:13Z] Created RayCluster test-ns-bkv54/raycluster successfully
    rayjob_cluster_selector_test.go:37: [2026-04-28T08:28:13Z] Waiting for RayCluster test-ns-bkv54/raycluster to become ready
=== RUN   TestRayJobWithClusterSelector/Successful_RayJob
    rayjob_cluster_selector_test.go:57: [2026-04-28T08:28:39Z] Created RayJob test-ns-bkv54/counter successfully
    rayjob_cluster_selector_test.go:59: [2026-04-28T08:28:39Z] Waiting for RayJob test-ns-bkv54/counter to complete
--- PASS: TestRayJobWithClusterSelector/Successful_RayJob (14.81s)
=== RUN   TestRayJobWithClusterSelector/Failing_RayJob
    rayjob_cluster_selector_test.go:81: [2026-04-28T08:28:54Z] Created RayJob test-ns-bkv54/fail successfully
    rayjob_cluster_selector_test.go:83: [2026-04-28T08:28:54Z] Waiting for RayJob test-ns-bkv54/fail to complete
--- PASS: TestRayJobWithClusterSelector/Failing_RayJob (10.06s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally
    rayjob_cluster_selector_test.go:109: [2026-04-28T08:29:04Z] Created RayJob test-ns-bkv54/managed-externally successfully
--- PASS: TestRayJobWithClusterSelector/RayJob_should_be_created_but_not_to_be_updated_when_managed_externally (3.20s)
=== RUN   TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value
--- PASS: TestRayJobWithClusterSelector/RayJob_should_not_be_created_due_to_managedBy_invalid_value (0.19s)
    test.go:114: [2026-04-28T08:29:08Z] Retrieving Pod Container test-ns-bkv54/counter-ftwkz/ray-job-submitter logs
    test.go:102: [2026-04-28T08:29:08Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2026-04-28T08:29:08Z] Output directory has been created at: /tmp/TestRayJobWithClusterSelector2542726707/001
    test.go:114: [2026-04-28T08:29:08Z] Retrieving Pod Container test-ns-bkv54/fail-cswvx/ray-job-submitter logs
    test.go:114: [2026-04-28T08:29:08Z] Retrieving Pod Container test-ns-bkv54/raycluster-head-vs6zg/ray-head logs
    test.go:114: [2026-04-28T08:29:09Z] Retrieving Pod Container test-ns-bkv54/raycluster-head-vs6zg/kube-rbac-proxy logs
    test.go:114: [2026-04-28T08:29:09Z] Retrieving Pod Container test-ns-bkv54/raycluster-small-group-worker-8m5hl/ray-worker logs
--- PASS: TestRayJobWithClusterSelector (58.06s)
=== RUN   TestRayJobLightWeightMode
    rayjob_lightweight_test.go:27: [2026-04-28T08:29:10Z] Created ConfigMap test-ns-h78pm/jobs successfully
=== RUN   TestRayJobLightWeightMode/Successful_RayJob
    rayjob_lightweight_test.go:56: [2026-04-28T08:29:10Z] Created RayJob test-ns-h78pm/counter successfully
    rayjob_lightweight_test.go:58: [2026-04-28T08:29:10Z] Waiting for RayJob test-ns-h78pm/counter to complete
--- PASS: TestRayJobLightWeightMode/Successful_RayJob (26.69s)
=== RUN   TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_lightweight_test.go:90: [2026-04-28T08:29:37Z] Created RayJob test-ns-h78pm/fail successfully
    rayjob_lightweight_test.go:92: [2026-04-28T08:29:37Z] Waiting for RayJob test-ns-h78pm/fail to complete
--- PASS: TestRayJobLightWeightMode/Failing_RayJob_without_cluster_shutdown_after_finished (33.36s)
=== RUN   TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_lightweight_test.go:121: [2026-04-28T08:30:10Z] Created RayJob test-ns-h78pm/stop successfully
    rayjob_lightweight_test.go:123: [2026-04-28T08:30:10Z] Waiting for RayJob test-ns-h78pm/stop to be 'Running'
    rayjob_lightweight_test.go:127: [2026-04-28T08:30:37Z] Waiting for RayJob test-ns-h78pm/stop to be 'Complete'
    rayjob_lightweight_test.go:137: [2026-04-28T08:31:02Z] Deleted RayJob test-ns-h78pm/stop successfully
--- PASS: TestRayJobLightWeightMode/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (52.40s)
    test.go:114: [2026-04-28T08:31:03Z] Retrieving Pod Container test-ns-h78pm/fail-b5ksf-head-lwt4p/ray-head logs
    test.go:102: [2026-04-28T08:31:03Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2026-04-28T08:31:03Z] Output directory has been created at: /tmp/TestRayJobLightWeightMode3661514514/001
    test.go:114: [2026-04-28T08:31:03Z] Retrieving Pod Container test-ns-h78pm/fail-b5ksf-head-lwt4p/kube-rbac-proxy logs
    test.go:114: [2026-04-28T08:31:03Z] Retrieving Pod Container test-ns-h78pm/fail-b5ksf-small-group-worker-8t8m7/ray-worker logs
    test.go:114: [2026-04-28T08:31:03Z] Retrieving Pod Container test-ns-h78pm/stop-vc4zq-head-cvhnh/ray-head logs
    test.go:114: [2026-04-28T08:31:04Z] Retrieving Pod Container test-ns-h78pm/stop-vc4zq-head-cvhnh/kube-rbac-proxy logs
    test.go:114: [2026-04-28T08:31:04Z] Retrieving Pod Container test-ns-h78pm/stop-vc4zq-small-group-worker-9twvh/ray-worker logs
    test.go:114: [2026-04-28T08:31:04Z] Error getting logs from container test-ns-h78pm/stop-vc4zq-small-group-worker-9twvh/ray-worker
--- PASS: TestRayJobLightWeightMode (115.13s)
=== RUN   TestRayJobSuspend
    rayjob_suspend_test.go:27: [2026-04-28T08:31:05Z] Created ConfigMap test-ns-t46zj/jobs successfully
=== RUN   TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it.
    rayjob_suspend_test.go:41: [2026-04-28T08:31:05Z] Created RayJob test-ns-t46zj/long-running successfully
    rayjob_suspend_test.go:43: [2026-04-28T08:31:05Z] Waiting for RayJob test-ns-t46zj/long-running to be 'Running'
4errrr    rayjob_suspend_test.go:47: [2026-04-28T08:31:32Z] Suspend the RayJob test-ns-t46zj/long-running
    rayjob_suspend_test.go:52: [2026-04-28T08:31:32Z] Waiting for RayJob test-ns-t46zj/long-running to be 'Suspended'
    rayjob_suspend_test.go:68: [2026-04-28T08:31:32Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:78: [2026-04-28T08:31:59Z] Deleted RayJob test-ns-t46zj/long-running successfully
--- PASS: TestRayJobSuspend/Suspend_the_RayJob_when_its_status_is_'Running',_and_then_resume_it. (54.39s)
=== RUN   TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it.
    rayjob_suspend_test.go:97: [2026-04-28T08:32:00Z] Created RayJob test-ns-t46zj/counter successfully
    rayjob_suspend_test.go:99: [2026-04-28T08:32:00Z] Waiting for RayJob test-ns-t46zj/counter to be 'Suspended'
    rayjob_suspend_test.go:103: [2026-04-28T08:32:00Z] Resume the RayJob by updating `suspend` to false.
    rayjob_suspend_test.go:108: [2026-04-28T08:32:00Z] Waiting for RayJob test-ns-t46zj/counter to complete
    rayjob_suspend_test.go:123: [2026-04-28T08:32:46Z] Deleted RayJob test-ns-t46zj/counter successfully
--- PASS: TestRayJobSuspend/Create_a_suspended_RayJob,_and_then_resume_it. (47.09s)
    test.go:102: [2026-04-28T08:32:47Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2026-04-28T08:32:47Z] Output directory has been created at: /tmp/TestRayJobSuspend796266694/001
--- PASS: TestRayJobSuspend (102.58s)
=== RUN   TestRayJob
    rayjob_test.go:29: [2026-04-28T08:32:48Z] Created ConfigMap test-ns-rp8nd/jobs successfully
=== RUN   TestRayJob/Successful_RayJob
    rayjob_test.go:46: [2026-04-28T08:32:48Z] Created RayJob test-ns-rp8nd/counter successfully
    rayjob_test.go:48: [2026-04-28T08:32:48Z] Waiting for RayJob test-ns-rp8nd/counter to complete
    rayjob_test.go:64: [2026-04-28T08:33:34Z] Checking that the RayJob status info has been set correctly.
    rayjob_test.go:81: [2026-04-28T08:33:34Z] Update `suspend` to true. However, since the RayJob is completed, the status should not be updated to `Suspended`.
    rayjob_test.go:91: [2026-04-28T08:34:04Z] Deleted RayJob test-ns-rp8nd/counter successfully
--- PASS: TestRayJob/Successful_RayJob (76.87s)
=== RUN   TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished
    rayjob_test.go:105: [2026-04-28T08:34:05Z] Created RayJob test-ns-rp8nd/fail successfully
    rayjob_test.go:107: [2026-04-28T08:34:05Z] Waiting for RayJob test-ns-rp8nd/fail to complete
    rayjob_test.go:130: [2026-04-28T08:34:49Z] Deleted RayJob test-ns-rp8nd/fail successfully
--- PASS: TestRayJob/Failing_RayJob_without_cluster_shutdown_after_finished (45.32s)
=== RUN   TestRayJob/Failing_submitter_K8s_Job
    rayjob_test.go:158: [2026-04-28T08:34:50Z] Created RayJob test-ns-rp8nd/fail-k8s-job successfully
    rayjob_test.go:160: [2026-04-28T08:34:50Z] Waiting for RayJob test-ns-rp8nd/fail-k8s-job to complete
    rayjob_test.go:183: [2026-04-28T08:36:02Z] Deleted RayJob test-ns-rp8nd/fail-k8s-job successfully
--- PASS: TestRayJob/Failing_submitter_K8s_Job (71.79s)
=== RUN   TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped.
    rayjob_test.go:197: [2026-04-28T08:36:02Z] Created RayJob test-ns-rp8nd/stop successfully
    rayjob_test.go:199: [2026-04-28T08:36:02Z] Waiting for RayJob test-ns-rp8nd/stop to be 'Running'
    rayjob_test.go:203: [2026-04-28T08:36:26Z] Waiting for RayJob test-ns-rp8nd/stop to be 'Complete'
    rayjob_test.go:213: [2026-04-28T08:37:02Z] Deleted RayJob test-ns-rp8nd/stop successfully
--- PASS: TestRayJob/Should_transition_to_'Complete'_if_the_Ray_job_has_stopped. (60.68s)
=== RUN   TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string
    rayjob_test.go:225: [2026-04-28T08:37:02Z] Created RayJob test-ns-rp8nd/invalid-yamlstr successfully
--- PASS: TestRayJob/RuntimeEnvYAML_is_not_a_valid_YAML_string (5.22s)
=== RUN   TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds
    rayjob_test.go:244: [2026-04-28T08:37:08Z] Created RayJob test-ns-rp8nd/long-running successfully
    rayjob_test.go:247: [2026-04-28T08:37:08Z] Waiting for RayJob test-ns-rp8nd/long-running to be 'Complete'
--- PASS: TestRayJob/RayJob_has_passed_ActiveDeadlineSeconds (6.67s)
=== RUN   TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally
    rayjob_test.go:270: [2026-04-28T08:37:14Z] Created RayJob test-ns-rp8nd/managed-externally successfully
    rayjob_test.go:296: [2026-04-28T08:37:16Z] Deleted RayJob test-ns-rp8nd/managed-externally successfully
--- PASS: TestRayJob/RayJob_should_be_created,_but_not_updated_when_managed_externally (1.90s)
    test.go:114: [2026-04-28T08:37:16Z] Retrieving Pod Container test-ns-rp8nd/long-running-dwjw6-head-tl8f2/ray-head logs
    test.go:102: [2026-04-28T08:37:17Z] Creating ephemeral output directory as KUBERAY_TEST_OUTPUT_DIR env variable is unset
    test.go:105: [2026-04-28T08:37:17Z] Output directory has been created at: /tmp/TestRayJob2164549060/001
    test.go:114: [2026-04-28T08:37:17Z] Retrieving Pod Container test-ns-rp8nd/long-running-dwjw6-head-tl8f2/kube-rbac-proxy logs
    test.go:114: [2026-04-28T08:37:17Z] Retrieving Pod Container test-ns-rp8nd/long-running-dwjw6-small-group-worker-pfftb/ray-worker logs
    test.go:114: [2026-04-28T08:37:17Z] Error getting logs from container test-ns-rp8nd/long-running-dwjw6-small-group-worker-pfftb/ray-worker
--- PASS: TestRayJob (270.33s)
PASS
ok  	github.com/ray-project/kuberay/ray-operator/test/e2e	546.214s

DONE 20 tests in 546.218s
```

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to exclusively support `Tier1` testing. `Sanity` testing and combined tier options are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->