### PR TITLE
RHOAIENG-37986: add Smoke tier e2e test for authentication validation

### DIFF
--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -16,11 +16,13 @@ EXTRA_ARGS=()
 show_usage() {
     echo "Usage: $0 [OPTIONS]"
     echo "Options:"
-    echo "  -testTier=VALUE    Specify test tier (only Tier1 is supported)"
+    echo "  -testTier=VALUE    Specify test tier(s): Tier1, Smoke"
     echo "  -h, -help          Show this help message"
     echo ""
     echo "Examples:"
     echo "  $0 -testTier=Tier1"
+    echo "  $0 -testTier=Smoke"
+    echo "  $0 -testTier=Tier1,Smoke"
     exit 0
 }
 
@@ -52,21 +54,43 @@ if [[ -z "$TEST_TAGS" ]]; then
     show_usage
 fi
 
-TEST_RUN_REGEX=""
+REGEX_PARTS=()
 
-# Handle different combinations of test tags
-if [[ "$TEST_TAGS" == *"Tier1"* ]]; then
-    echo "Running Tier1 kuberay e2e tests"
-    TEST_RUN_REGEX="^(TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode)$"
-elif [[ "$TEST_TAGS" == *"Sanity"* ]]; then
-    echo "Warning: 'Sanity' tier is no longer supported. Only 'Tier1' is supported."
-    echo ""
-    show_usage
-else
-    echo "Info: Invalid test tier '$TEST_TAGS'. Only 'Tier1' is supported."
-    echo ""
+IFS=',' read -ra TIER_LIST <<< "$TEST_TAGS"
+for TIER in "${TIER_LIST[@]}"; do
+    # trim leading/trailing whitespace
+    TIER="${TIER#"${TIER%%[![:space:]]*}"}"
+    TIER="${TIER%"${TIER##*[![:space:]]}"}"
+    [[ -z "$TIER" ]] && continue
+    case "$TIER" in
+        Tier1)
+            echo "Adding Tier1 kuberay e2e tests"
+            REGEX_PARTS+=("TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode")
+            ;;
+        Smoke)
+            echo "Adding Smoke kuberay e2e tests (authentication validation)"
+            REGEX_PARTS+=("TestRayClusterAuthentication")
+            ;;
+        Sanity)
+            echo "Warning: 'Sanity' tier is no longer supported. Use 'Tier1' or 'Smoke'."
+            echo ""
+            show_usage
+            ;;
+        *)
+            echo "Info: Invalid test tier '$TIER'. Supported tiers: Tier1, Smoke."
+            echo ""
+            show_usage
+            ;;
+    esac
+done
+
+if [[ ${#REGEX_PARTS[@]} -eq 0 ]]; then
+    echo "Error: No valid test tiers resolved."
     show_usage
 fi
+
+TEST_RUN_REGEX="^($(IFS='|'; echo "${REGEX_PARTS[*]}"))$"
+echo "Running e2e tests matching: $TEST_RUN_REGEX"
 
 # Run tests with junit XML output
 gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout 30m -run "$TEST_RUN_REGEX" ./test/e2e -p 1 -parallel 1 "${EXTRA_ARGS[@]}"

--- a/ray-operator/test/e2e/raycluster_auth_test.go
+++ b/ray-operator/test/e2e/raycluster_auth_test.go
@@ -1,0 +1,90 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	rayv1ac "github.com/ray-project/kuberay/ray-operator/pkg/client/applyconfiguration/ray/v1"
+	. "github.com/ray-project/kuberay/ray-operator/test/support"
+)
+
+const (
+	oidcProxySidecarName = "kube-rbac-proxy"
+	authProxyPortNum     = 8443
+)
+
+func TestRayClusterAuthentication(t *testing.T) {
+	test := With(t)
+	g := NewWithT(t)
+
+	namespace := test.NewTestNamespace()
+
+	rayClusterAC := rayv1ac.RayCluster("raycluster-auth", namespace.Name).
+		WithAnnotations(map[string]string{
+			utils.EnableSecureTrustedNetworkAnnotationKey: "true",
+		}).
+		WithSpec(newRayClusterSpec())
+
+	rayCluster, err := test.Client().Ray().RayV1().RayClusters(namespace.Name).Apply(test.Ctx(), rayClusterAC, TestApplyOptions)
+	g.Expect(err).NotTo(HaveOccurred())
+	LogWithTimestamp(test.T(), "Created RayCluster %s/%s with authentication enabled", rayCluster.Namespace, rayCluster.Name)
+
+	LogWithTimestamp(test.T(), "Waiting for RayCluster %s/%s to become ready", rayCluster.Namespace, rayCluster.Name)
+	g.Eventually(RayCluster(test, rayCluster.Namespace, rayCluster.Name), TestTimeoutMedium).
+		Should(WithTransform(RayClusterState, Equal(rayv1.Ready)))
+
+	headPod, err := GetHeadPod(test, rayCluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(headPod).NotTo(BeNil())
+
+	test.T().Run("Auth proxy sidecar is injected into head pod", func(_ *testing.T) {
+		var found bool
+		for _, c := range headPod.Spec.Containers {
+			if c.Name == oidcProxySidecarName {
+				found = true
+				break
+			}
+		}
+		g.Expect(found).To(BeTrue(), "Head pod should have %s sidecar container", oidcProxySidecarName)
+
+		var statusFound bool
+		for _, cs := range headPod.Status.ContainerStatuses {
+			if cs.Name == oidcProxySidecarName {
+				statusFound = true
+				g.Expect(cs.Ready).To(BeTrue(), "%s container should be ready", oidcProxySidecarName)
+			}
+		}
+		g.Expect(statusFound).To(BeTrue(), "ContainerStatuses should include %s", oidcProxySidecarName)
+	})
+
+	test.T().Run("Unauthenticated request to auth proxy is rejected", func(_ *testing.T) {
+		pythonScript := fmt.Sprintf(`
+import urllib.request, ssl
+ctx = ssl.create_default_context()
+ctx.check_hostname = False
+ctx.verify_mode = ssl.CERT_NONE
+try:
+    urllib.request.urlopen(urllib.request.Request('https://localhost:%d/'), context=ctx, timeout=5)
+    print('STATUS:200')
+except urllib.error.HTTPError as e:
+    print('STATUS:' + str(e.code))
+except Exception as e:
+    print('ERROR:' + str(e))
+`, authProxyPortNum)
+
+		cmd := []string{"python3", "-c", pythonScript}
+
+		g.Eventually(func(g Gomega) {
+			stdout, _ := ExecPodCmd(test, headPod, "ray-head", cmd)
+			output := stdout.String()
+			g.Expect(output).To(SatisfyAny(
+				ContainSubstring("STATUS:401"),
+				ContainSubstring("STATUS:403"),
+			), "Unauthenticated request should be rejected, got: %s", output)
+		}, TestTimeoutShort).Should(Succeed())
+	})
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Why are these changes needed?

After the removal of the codeflare-operator, KubeRay is now solely responsible for handling authentication on RHOAI. This PR adds an end-to-end Smoke test (TestRayClusterAuthentication) that validates KubeRay's authentication controller correctly configures OAuth for RayClusters. The test creates a RayCluster with the odh.ray.io/secure-trusted-network: "true" annotation, verifies the kube-rbac-proxy sidecar container is injected into the head pod, and confirms that unauthenticated requests to the auth proxy are rejected with a 401/403 HTTP status.

Additionally, the run-tests.sh script is updated to support a new Smoke test tier (-testTier=Smoke) so this authentication test runs as part of nightly builds.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

Closes [RHOAIENG-37986](https://redhat.atlassian.net/browse/RHOAIENG-37986)

## Verification

This was verified on a live OpenShift cluster (ROSA).

Test output:

```
=== RUN   TestRayClusterAuthentication
    raycluster_auth_test.go:34: [2026-04-28T15:25:07+01:00] Created RayCluster test-ns-9lwwt/raycluster-auth with authentication enabled
    raycluster_auth_test.go:36: [2026-04-28T15:25:07+01:00] Waiting for RayCluster test-ns-9lwwt/raycluster-auth to become ready
=== RUN   TestRayClusterAuthentication/Auth_proxy_sidecar_is_injected_into_head_pod
=== RUN   TestRayClusterAuthentication/Unauthenticated_request_to_auth_proxy_is_rejected
    core.go:100: [2026-04-28T15:31:45+01:00] Command stdout: STATUS:401
--- PASS: TestRayClusterAuthentication (398.96s)
    --- PASS: TestRayClusterAuthentication/Auth_proxy_sidecar_is_injected_into_head_pod (0.00s)
    --- PASS: TestRayClusterAuthentication/Unauthenticated_request_to_auth_proxy_is_rejected (0.90s)
PASS
```
## Steps to verify manually:

1. Ensure you are logged into an OpenShift cluster with the KubeRay operator deployed (with authentication controller enabled):

`oc login --token=<your-token> --server=<cluster-api-url>`

2. Set the Ray image to use (must match your cluster architecture):

`export KUBERAY_TEST_RAY_IMAGE=quay.io/modh/ray:2.53.0-py312-cu128`

3. Run the e2e test from the ray-operator directory:

```
cd ray-operator
go test -v -timeout 30m -count=1 -run '^TestRayClusterAuthentication$' ./test/e2e/
```
Note: If running from an ARM Mac against an x86_64 cluster, prefix with GOARCH=amd64 to prevent the test helper from appending an -aarch64 suffix to the image tag.

4. Verify the run-tests.sh Smoke tier works:

`bash ray-operator/images/tests/run-tests.sh -testTier=Smoke`

5. Both subtests should pass:

- Auth proxy sidecar is injected into head pod — confirms kube-rbac-proxy container is present and ready in the head pod.
- Unauthenticated request to auth proxy is rejected — confirms an HTTPS request without credentials to port 8443 returns STATUS:401 or STATUS:403.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Accept multiple comma-separated test tiers and map a combined "Smoke" tier alongside Tier1; unknown or empty tiers now show usage guidance.
  * Shows the final test-selection pattern before running tests for transparency.
  * Adds an end-to-end authentication test for Ray clusters that ensures the auth proxy is injected and that unauthenticated requests are rejected (HTTP 401/403).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->