### PR TITLE
CARRY: task(RHOAIENG-59432): fix RoleBinding for autoscaling

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -371,6 +371,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -256,6 +256,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -17,7 +18,8 @@ import (
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +37,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
@@ -69,6 +72,8 @@ const (
 // the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE (set in manager.yaml and
 // substituted by the deployer from the RHOAI CSV relatedImages at install time).
 var oidcProxyContainerImage = defaultOIDCProxyContainerImage
+
+var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not found yet")
 
 func init() {
 	for _, envVar := range []string{
@@ -109,6 +114,7 @@ func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcil
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers/status,verbs=get;list;watch
@@ -131,7 +137,7 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	// Get the RayCluster - this should always be a RayCluster now due to proper mapping
 	rayCluster := &rayv1.RayCluster{}
 	if err := r.Get(ctx, req.NamespacedName, rayCluster); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.Info("RayCluster not found, likely deleted - checking for orphaned resources")
 			// Clean up any orphaned ReferenceGrants in this namespace
 			if err := r.cleanupOrphanedReferenceGrant(ctx, req.Namespace, logger); err != nil {
@@ -173,12 +179,15 @@ func (r *AuthenticationController) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	if err != nil {
+		if errors.Is(err, errAutoscalerRoleBindingPending) {
+			logger.Info("Autoscaler RoleBinding not ready yet, requeueing", "cluster", rayCluster.Name)
+			return ctrl.Result{RequeueAfter: MediumRequeueDelay}, nil
+		}
 		logger.Error(err, "Failed to handle authentication configuration")
 		return ctrl.Result{RequeueAfter: MediumRequeueDelay}, err
 	}
 
 	logger.Info("Successfully reconciled authentication", "cluster", rayCluster.Name)
-	// Don't requeue on success - let watches trigger next reconciliation
 	return ctrl.Result{}, nil
 }
 
@@ -313,6 +322,14 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 func (r *AuthenticationController) ensureOIDCResources(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) error {
 	if err := r.ensureServiceAccount(ctx, cluster, authMode, logger); err != nil {
 		return fmt.Errorf("failed to ensure service account: %w", err)
+	}
+
+	pending, err := r.ensureAutoscalerRoleBindingForAuthSA(ctx, cluster, authMode, logger)
+	if err != nil {
+		return fmt.Errorf("failed to ensure autoscaler RoleBinding includes auth SA: %w", err)
+	}
+	if pending {
+		return errAutoscalerRoleBindingPending
 	}
 
 	// Create ReferenceGrant BEFORE HTTPRoute to enable cross-namespace service references
@@ -566,7 +583,7 @@ func (r *AuthenticationController) cleanupOldHTTPRouteFromClusterNamespace(ctx c
 
 	err := r.Get(ctx, client.ObjectKey{Name: oldHttpRouteName, Namespace: cluster.Namespace}, oldHttpRoute)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// No old HTTPRoute to clean up - this is the normal case
 			logger.V(1).Info("No old HTTPRoute found in cluster namespace (already migrated or never existed)",
 				"name", oldHttpRouteName,
@@ -592,7 +609,7 @@ func (r *AuthenticationController) cleanupOldHTTPRouteFromClusterNamespace(ctx c
 	}
 
 	if err := r.Delete(ctx, oldHttpRoute); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// Already deleted (race condition) - that's fine
 			return nil
 		}
@@ -728,7 +745,7 @@ func (r *AuthenticationController) cleanupReferenceGrant(ctx context.Context, cl
 		grant := &gatewayv1beta1.ReferenceGrant{}
 		err := r.Get(ctx, client.ObjectKey{Name: grantName, Namespace: cluster.Namespace}, grant)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				logger.Info("ReferenceGrant already deleted", "name", grantName)
 				return nil
 			}
@@ -832,6 +849,50 @@ func (r *AuthenticationController) ensureServiceAccount(ctx context.Context, clu
 	}
 
 	return nil
+}
+
+// ensureAutoscalerRoleBindingForAuthSA patches the autoscaler RoleBinding to include the auth proxy SA.
+// Returns pending=true when the RayCluster reconciler has not created the RoleBinding yet.
+func (r *AuthenticationController) ensureAutoscalerRoleBindingForAuthSA(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) (pending bool, err error) {
+	if !utils.IsAutoscalingEnabled(&cluster.Spec) {
+		return false, nil
+	}
+
+	namer := utils.NewResourceNamer(cluster)
+	authSAName := namer.ServiceAccountName(authMode)
+
+	roleBinding := &rbacv1.RoleBinding{}
+	namespacedName := common.RayClusterAutoscalerRoleBindingNamespacedName(cluster)
+	if err := r.Get(ctx, namespacedName, roleBinding); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("Autoscaler RoleBinding does not exist yet, will retry auth SA patch", "cluster", cluster.Name)
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to get autoscaler RoleBinding: %w", err)
+	}
+
+	for _, s := range roleBinding.Subjects {
+		if s.Kind == rbacv1.ServiceAccountKind && s.Name == authSAName && s.Namespace == cluster.Namespace {
+			return false, nil
+		}
+	}
+
+	patch := client.MergeFrom(roleBinding.DeepCopy())
+	roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      authSAName,
+		Namespace: cluster.Namespace,
+	})
+
+	if err := r.Patch(ctx, roleBinding, patch); err != nil {
+		return false, fmt.Errorf("failed to patch autoscaler RoleBinding with auth SA: %w", err)
+	}
+
+	logger.Info("Added auth proxy SA to autoscaler RoleBinding",
+		"roleBinding", namespacedName,
+		"authServiceAccount", authSAName,
+		"mode", authMode)
+	return false, nil
 }
 
 // ensureOAuthServiceAccount creates or updates the OAuth service account
@@ -1038,7 +1099,7 @@ func (r *AuthenticationController) cleanupOrphanedReferenceGrant(ctx context.Con
 		grant := &gatewayv1beta1.ReferenceGrant{}
 		err := r.Get(ctx, client.ObjectKey{Name: grantName, Namespace: namespace}, grant)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				logger.Info("No orphaned ReferenceGrant found", "namespace", namespace)
 				return nil
 			}

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/common"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 )
 
@@ -85,6 +87,7 @@ func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcil
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers/status,verbs=get;list;watch
@@ -289,6 +292,10 @@ func (r *AuthenticationController) handleOIDCConfiguration(ctx context.Context, 
 func (r *AuthenticationController) ensureOIDCResources(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) error {
 	if err := r.ensureServiceAccount(ctx, cluster, authMode, logger); err != nil {
 		return fmt.Errorf("failed to ensure service account: %w", err)
+	}
+
+	if err := r.ensureAutoscalerRoleBindingForAuthSA(ctx, cluster, authMode, logger); err != nil {
+		return fmt.Errorf("failed to ensure autoscaler RoleBinding includes auth SA: %w", err)
 	}
 
 	// Create ReferenceGrant BEFORE HTTPRoute to enable cross-namespace service references
@@ -807,6 +814,51 @@ func (r *AuthenticationController) ensureServiceAccount(ctx context.Context, clu
 		logger.Info("Service account reconciled", "name", saName, "operation", opResult, "mode", authMode)
 	}
 
+	return nil
+}
+
+// ensureAutoscalerRoleBindingForAuthSA patches the autoscaler RoleBinding (if it exists)
+// to include the auth proxy ServiceAccount as an additional subject. When the auth
+// controller overrides the head pod's SA, the autoscaler sidecar runs under the new SA
+// and needs permission to get/patch RayClusters.
+func (r *AuthenticationController) ensureAutoscalerRoleBindingForAuthSA(ctx context.Context, cluster *rayv1.RayCluster, authMode utils.AuthenticationMode, logger logr.Logger) error {
+	if !utils.IsAutoscalingEnabled(&cluster.Spec) {
+		return nil
+	}
+
+	namer := utils.NewResourceNamer(cluster)
+	authSAName := namer.ServiceAccountName(authMode)
+
+	roleBinding := &rbacv1.RoleBinding{}
+	namespacedName := common.RayClusterAutoscalerRoleBindingNamespacedName(cluster)
+	if err := r.Get(ctx, namespacedName, roleBinding); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Autoscaler RoleBinding does not exist yet, skipping auth SA patch", "cluster", cluster.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to get autoscaler RoleBinding: %w", err)
+	}
+
+	for _, s := range roleBinding.Subjects {
+		if s.Kind == rbacv1.ServiceAccountKind && s.Name == authSAName && s.Namespace == cluster.Namespace {
+			return nil
+		}
+	}
+
+	roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+		Kind:      rbacv1.ServiceAccountKind,
+		Name:      authSAName,
+		Namespace: cluster.Namespace,
+	})
+
+	if err := r.Update(ctx, roleBinding); err != nil {
+		return fmt.Errorf("failed to update autoscaler RoleBinding with auth SA: %w", err)
+	}
+
+	logger.Info("Added auth proxy SA to autoscaler RoleBinding",
+		"roleBinding", namespacedName,
+		"authServiceAccount", authSAName,
+		"mode", authMode)
 	return nil
 }
 

--- a/ray-operator/controllers/ray/authentication_controller_unit_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_unit_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,7 @@ import (
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = corev1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
 	_ = rayv1.AddToScheme(s)
 	_ = configv1.AddToScheme(s)
 	_ = routev1.AddToScheme(s)
@@ -1169,4 +1171,232 @@ func TestEnforceEnableIngressFalseOnOpenShift_Idempotency(t *testing.T) {
 	require.NotNil(t, updated.Spec.HeadGroupSpec.EnableIngress)
 	assert.False(t, *updated.Spec.HeadGroupSpec.EnableIngress,
 		"EnableIngress should be false after multiple enforcements")
+}
+
+func TestEnsureAutoscalerRoleBindingForAuthSA(t *testing.T) {
+	tests := []struct {
+		cluster        *rayv1.RayCluster
+		existingRB     *rbacv1.RoleBinding
+		name           string
+		authMode       utils.AuthenticationMode
+		expectSubjects int
+		expectPending  bool
+		expectAuthSA   bool
+		expectNoUpdate bool
+	}{
+		{
+			name: "Autoscaling disabled - no-op",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(false),
+				},
+			},
+			existingRB:     nil,
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 0,
+			expectAuthSA:   false,
+			expectNoUpdate: true,
+		},
+		{
+			name: "RoleBinding does not exist yet - pending",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB:     nil,
+			authMode:       utils.ModeIntegratedOAuth,
+			expectPending:  true,
+			expectSubjects: 0,
+			expectAuthSA:   false,
+			expectNoUpdate: true,
+		},
+		{
+			name: "RoleBinding exists - adds OAuth proxy SA",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "test-cluster",
+				},
+			},
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+		},
+		{
+			name: "RoleBinding exists - adds OIDC proxy SA",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "test-cluster",
+				},
+			},
+			authMode:       utils.ModeOIDC,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+		},
+		{
+			name: "Auth SA already present - idempotent",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: func() *rbacv1.RoleBinding {
+				cluster := &rayv1.RayCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "default"}}
+				namer := utils.NewResourceNamer(cluster)
+				return &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind:      rbacv1.ServiceAccountKind,
+							Name:      "test-cluster",
+							Namespace: "default",
+						},
+						{
+							Kind:      rbacv1.ServiceAccountKind,
+							Name:      namer.ServiceAccountName(utils.ModeIntegratedOAuth),
+							Namespace: "default",
+						},
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "test-cluster",
+					},
+				}
+			}(),
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+			expectNoUpdate: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := setupScheme()
+
+			objects := []runtime.Object{tc.cluster}
+			if tc.existingRB != nil {
+				objects = append(objects, tc.existingRB)
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(objects...).
+				Build()
+
+			controller := &AuthenticationController{
+				Client:   fakeClient,
+				Scheme:   s,
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			pending, err := controller.ensureAutoscalerRoleBindingForAuthSA(ctx, tc.cluster, tc.authMode, ctrl.Log)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectPending, pending)
+
+			if tc.existingRB == nil {
+				rb := &rbacv1.RoleBinding{}
+				err = fakeClient.Get(ctx, types.NamespacedName{
+					Name:      tc.cluster.Name,
+					Namespace: tc.cluster.Namespace,
+				}, rb)
+				assert.True(t, errors.IsNotFound(err), "RoleBinding should not be created")
+				return
+			}
+
+			rb := &rbacv1.RoleBinding{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      tc.cluster.Name,
+				Namespace: tc.cluster.Namespace,
+			}, rb)
+			require.NoError(t, err)
+			assert.Len(t, rb.Subjects, tc.expectSubjects)
+
+			if tc.expectNoUpdate {
+				assert.Equal(t, tc.existingRB.Subjects, rb.Subjects, "Subjects should remain unchanged")
+				return
+			}
+
+			if tc.expectAuthSA {
+				namer := utils.NewResourceNamer(tc.cluster)
+				expectedSA := namer.ServiceAccountName(tc.authMode)
+				found := false
+				for _, s := range rb.Subjects {
+					if s.Kind == rbacv1.ServiceAccountKind &&
+						s.Name == expectedSA &&
+						s.Namespace == tc.cluster.Namespace {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Auth SA %s should be in RoleBinding subjects", expectedSA)
+			}
+		})
+	}
 }

--- a/ray-operator/controllers/ray/authentication_controller_unit_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_unit_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,7 @@ import (
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = corev1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
 	_ = rayv1.AddToScheme(s)
 	_ = configv1.AddToScheme(s)
 	_ = routev1.AddToScheme(s)
@@ -1169,4 +1171,221 @@ func TestEnforceEnableIngressFalseOnOpenShift_Idempotency(t *testing.T) {
 	require.NotNil(t, updated.Spec.HeadGroupSpec.EnableIngress)
 	assert.False(t, *updated.Spec.HeadGroupSpec.EnableIngress,
 		"EnableIngress should be false after multiple enforcements")
+}
+
+func TestEnsureAutoscalerRoleBindingForAuthSA(t *testing.T) {
+	tests := []struct {
+		name           string
+		cluster        *rayv1.RayCluster
+		existingRB     *rbacv1.RoleBinding
+		authMode       utils.AuthenticationMode
+		expectSubjects int
+		expectAuthSA   bool
+		expectNoUpdate bool
+	}{
+		{
+			name: "Autoscaling disabled - no-op",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(false),
+				},
+			},
+			existingRB:     nil,
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 0,
+			expectAuthSA:   false,
+			expectNoUpdate: true,
+		},
+		{
+			name: "RoleBinding does not exist yet - skip gracefully",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB:     nil,
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 0,
+			expectAuthSA:   false,
+			expectNoUpdate: true,
+		},
+		{
+			name: "RoleBinding exists - adds OAuth proxy SA",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "test-cluster",
+				},
+			},
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+		},
+		{
+			name: "RoleBinding exists - adds OIDC proxy SA",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "test-cluster",
+				},
+			},
+			authMode:       utils.ModeOIDC,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+		},
+		{
+			name: "Auth SA already present - idempotent",
+			cluster: &rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: rayv1.RayClusterSpec{
+					EnableInTreeAutoscaling: ptr.To(true),
+				},
+			},
+			existingRB: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster",
+						Namespace: "default",
+					},
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-cluster-oauth-proxy-sa",
+						Namespace: "default",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "test-cluster",
+				},
+			},
+			authMode:       utils.ModeIntegratedOAuth,
+			expectSubjects: 2,
+			expectAuthSA:   true,
+			expectNoUpdate: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := setupScheme()
+
+			objects := []runtime.Object{tc.cluster}
+			if tc.existingRB != nil {
+				objects = append(objects, tc.existingRB)
+			}
+
+			fakeClient := clientFake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(objects...).
+				Build()
+
+			controller := &AuthenticationController{
+				Client:   fakeClient,
+				Scheme:   s,
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			err := controller.ensureAutoscalerRoleBindingForAuthSA(ctx, tc.cluster, tc.authMode, ctrl.Log)
+			require.NoError(t, err)
+
+			if tc.existingRB == nil || tc.expectNoUpdate {
+				if tc.existingRB != nil {
+					rb := &rbacv1.RoleBinding{}
+					err = fakeClient.Get(ctx, types.NamespacedName{
+						Name:      tc.cluster.Name,
+						Namespace: tc.cluster.Namespace,
+					}, rb)
+					require.NoError(t, err)
+					assert.Len(t, rb.Subjects, tc.expectSubjects)
+				}
+				return
+			}
+
+			rb := &rbacv1.RoleBinding{}
+			err = fakeClient.Get(ctx, types.NamespacedName{
+				Name:      tc.cluster.Name,
+				Namespace: tc.cluster.Namespace,
+			}, rb)
+			require.NoError(t, err)
+			assert.Len(t, rb.Subjects, tc.expectSubjects)
+
+			if tc.expectAuthSA {
+				namer := utils.NewResourceNamer(tc.cluster)
+				expectedSA := namer.ServiceAccountName(tc.authMode)
+				found := false
+				for _, s := range rb.Subjects {
+					if s.Kind == rbacv1.ServiceAccountKind && s.Name == expectedSA {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Auth SA %s should be in RoleBinding subjects", expectedSA)
+			}
+		})
+	}
 }

--- a/ray-operator/controllers/ray/raycluster_controller.go
+++ b/ray-operator/controllers/ray/raycluster_controller.go
@@ -1284,6 +1284,12 @@ func (r *RayClusterReconciler) buildHeadPod(ctx context.Context, instance rayv1.
 	logger.Info("head pod labels", "labels", podConf.Labels)
 	creatorCRDType := getCreatorCRDType(instance)
 	pod := common.BuildPod(ctx, podConf, rayv1.HeadNode, instance.Spec.HeadGroupSpec.RayStartParams, headPort, autoscalingEnabled, creatorCRDType, fqdnRayIP)
+	if r.isMTLSEnabled(&instance) {
+		// With mTLS, --node-ip-address is the head service FQDN (see setMissingRayStartParams).
+		// Inject loopback RAY_ADDRESS after BuildPod so ray-head and autoscaler connect to GCS
+		// via 127.0.0.1, avoiding TLS SNI failures when using the pod IP.
+		r.injectMTLSLoopbackRayAddress(&pod, headPort)
+	}
 	// Set raycluster instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&instance, &pod, r.Scheme); err != nil {
 		logger.Error(err, "Failed to set controller reference for raycluster pod")
@@ -1367,8 +1373,79 @@ func (r *RayClusterReconciler) configureMTLSForPod(podTemplate *corev1.PodTempla
 		r.addCertVolumeMounts(&podTemplate.Spec.InitContainers[i])
 	}
 
+	// For head pods, prepend an init container that waits until the TLS certificate
+	// issued by cert-manager includes the pod's actual IP as an IP SAN. Without this,
+	// there is a race condition: cert-manager issues the initial certificate before the
+	// pod IP is known (so only the FQDN DNS SAN is present), and GCS loads this
+	// incomplete certificate at startup. Python clients that connect via the pod IP
+	// (after resolving the FQDN) then fail TLS verification because no IP SAN matches.
+	// Blocking GCS startup until the cert carries the pod's IP SAN eliminates the race.
+	if !isWorker && len(podTemplate.Spec.Containers) > 0 {
+		waitScript := `POD_IP="${MY_POD_IP}"
+CERT="/home/ray/workspace/tls/tls.crt"
+echo "Waiting for TLS cert to include IP SAN for ${POD_IP}..."
+while true; do
+  if openssl x509 -in "${CERT}" -noout -text 2>/dev/null | grep -q "IP Address:${POD_IP}"; then
+    echo "TLS cert now includes IP SAN for ${POD_IP}"
+    exit 0
+  fi
+  echo "IP SAN for ${POD_IP} not yet in cert, retrying in 5s..."
+  sleep 5
+done`
+		waitInitContainer := corev1.Container{
+			Name:  "wait-for-tls-ip-san",
+			Image: podTemplate.Spec.Containers[0].Image,
+			Env: []corev1.EnvVar{
+				{
+					Name: "MY_POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "ray-tls-vol",
+					MountPath: "/home/ray/workspace/tls",
+					ReadOnly:  true,
+				},
+			},
+			Command: []string{"sh", "-c"},
+			Args:    []string{waitScript},
+		}
+		podTemplate.Spec.InitContainers = append([]corev1.Container{waitInitContainer}, podTemplate.Spec.InitContainers...)
+	}
+
 	// Add CA volumes with proper secret references
 	r.addCAVolumes(&podTemplate.Spec, secretName)
+}
+
+// injectMTLSLoopbackRayAddress sets RAY_ADDRESS=127.0.0.1:port on ray-head and autoscaler.
+// Called only when mTLS is enabled for the RayCluster.
+func (r *RayClusterReconciler) injectMTLSLoopbackRayAddress(pod *corev1.Pod, headPort string) {
+	loopbackAddress := fmt.Sprintf("%s:%s", utils.LOCAL_HOST, headPort)
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if i != utils.RayContainerIndex && container.Name != common.AutoscalerContainerName {
+			continue
+		}
+		found := false
+		for j, env := range container.Env {
+			if env.Name == utils.RAY_ADDRESS {
+				container.Env[j].Value = loopbackAddress
+				found = true
+				break
+			}
+		}
+		if !found {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  utils.RAY_ADDRESS,
+				Value: loopbackAddress,
+			})
+		}
+	}
 }
 
 // addTLSEnvironmentVariables adds Ray TLS environment variables to a container
@@ -1979,14 +2056,14 @@ func (r *RayClusterReconciler) reconcileAutoscalerRoleBinding(ctx context.Contex
 		if err := r.Create(ctx, roleBinding); err != nil {
 			if errors.IsAlreadyExists(err) {
 				logger.Info("role binding already exist, no need to create")
-				return nil
+			} else {
+				r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToCreateRoleBinding), "Failed creating role binding %s/%s, %v", roleBinding.Namespace, roleBinding.Name, err)
+				return err
 			}
-			r.Recorder.Eventf(instance, corev1.EventTypeWarning, string(utils.FailedToCreateRoleBinding), "Failed creating role binding %s/%s, %v", roleBinding.Namespace, roleBinding.Name, err)
-			return err
+		} else {
+			logger.Info("Created role binding for Ray Autoscaler", "name", roleBinding.Name)
+			r.Recorder.Eventf(instance, corev1.EventTypeNormal, string(utils.CreatedRoleBinding), "Created role binding %s/%s", roleBinding.Namespace, roleBinding.Name)
 		}
-		logger.Info("Created role binding for Ray Autoscaler", "name", roleBinding.Name)
-		r.Recorder.Eventf(instance, corev1.EventTypeNormal, string(utils.CreatedRoleBinding), "Created role binding %s/%s", roleBinding.Namespace, roleBinding.Name)
-		return nil
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Changes in this PR are required to allow Ray autoscaling to work as intended via the CodeFlare SDK. See [this](https://redhat-internal.slack.com/archives/C087SCFQ3JM/p1776949675558269) thread for more context.

## Related issue number
[Jira](https://redhat.atlassian.net/browse/RHOAIENG-59432)

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth proxy service account is automatically added to autoscaler RoleBindings when auth+autoscaling are enabled.
  * mTLS: head and autoscaler containers use loopback for Ray address; a head-only init container delays startup until TLS cert includes the head Pod IP.

* **Chores**
  * Operator RBAC expanded to allow patch/update of RoleBindings.

* **Tests**
  * Unit tests added for RBAC auth+autoscaling behaviors and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->