### PR TITLE
CARRY: RHOAIENG-60157 - Suspend clusterSelector RayJobs correctly

### DIFF
--- a/ray-operator/controllers/ray/rayjob_controller.go
+++ b/ray-operator/controllers/ray/rayjob_controller.go
@@ -325,6 +325,55 @@ func (r *RayJobReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// cleaned up at all. To keep the atomicity, if a RayJob is in the `Suspending` status, we should delete all of its
 		// associated resources and then transition the status to `Suspended` no matter the value of the `suspend` flag.
 
+		// RayJob targets an existing RayCluster: stop the Ray job via the dashboard API; do not delete the cluster.
+		if len(rayJobInstance.Spec.ClusterSelector) != 0 {
+			if rayJobInstance.Status.DashboardURL != "" && rayJobInstance.Status.JobId != "" {
+				rayClusterNamespacedName := common.RayJobRayClusterNamespacedName(rayJobInstance)
+				rayClusterInstance := &rayv1.RayCluster{}
+				if err := r.Get(ctx, rayClusterNamespacedName, rayClusterInstance); err != nil {
+					if !errors.IsNotFound(err) {
+						logger.Error(err, "Failed to get RayCluster for clusterSelector suspend", "RayCluster", rayClusterNamespacedName)
+						return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+					}
+					logger.Info("RayCluster is already gone for clusterSelector suspend; continue suspend without stop request", "RayCluster", rayClusterNamespacedName)
+					rayJobInstance.Status.JobStatus = rayv1.JobStatusNew
+				} else {
+					rayDashboardClient := r.dashboardClientFunc()
+					if err := rayDashboardClient.InitClient(ctx, rayJobInstance.Status.DashboardURL, rayClusterInstance); err != nil {
+						logger.Error(err, "Failed to initialize dashboard client for clusterSelector suspend")
+						return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+					}
+					if err := rayDashboardClient.StopJob(ctx, rayJobInstance.Status.JobId); err != nil {
+						jobInfo, err2 := rayDashboardClient.GetJobInfo(ctx, rayJobInstance.Status.JobId)
+						if err2 != nil {
+							if !errors.IsBadRequest(err2) {
+								logger.Error(err, "Failed to stop Ray job for clusterSelector RayJob", "getJobInfoErr", err2)
+								return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+							}
+							logger.Info("StopJob failed but Ray job is not on the cluster; continuing suspend", "error", err)
+						} else if !rayv1.IsJobTerminal(jobInfo.JobStatus) {
+							logger.Error(err, "Failed to stop Ray job for clusterSelector RayJob")
+							return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+						}
+					}
+					rayJobInstance.Status.JobStatus = rayv1.JobStatusStopped
+				}
+			} else {
+				rayJobInstance.Status.JobStatus = rayv1.JobStatusNew
+			}
+			isJobDeleted, err := r.deleteSubmitterJob(ctx, rayJobInstance)
+			if err != nil {
+				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, err
+			}
+			if !isJobDeleted {
+				return ctrl.Result{RequeueAfter: RayJobDefaultRequeueDuration}, nil
+			}
+			rayJobInstance.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspended
+			rayJobInstance.Status.JobId = ""
+			rayJobInstance.Status.Message = ""
+			break
+		}
+
 		// TODO (kevin85421): Currently, Ray doesn't have a best practice to stop a Ray job gracefully. At this moment,
 		// KubeRay doesn't stop the Ray job before suspending the RayJob. If users want to stop the Ray job by SIGTERM,
 		// users need to set the Pod's preStop hook by themselves.

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	stdErrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,8 @@ var (
 	// Job URL paths
 	JobPath = "/api/jobs/"
 )
+
+const maxDashboardResponseBodyBytes int64 = 4 << 20 // 4 MiB
 
 type RayDashboardClientInterface interface {
 	InitClient(ctx context.Context, url string, rayCluster *rayv1.RayCluster) error
@@ -267,9 +270,9 @@ func (r *RayDashboardClient) GetJobInfo(ctx context.Context, jobId string) (*Ray
 		return nil, errors.NewBadRequest("Job " + jobId + " does not exist on the cluster")
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp.Body, maxDashboardResponseBodyBytes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetJobInfo fail: %w", err)
 	}
 
 	var jobInfo RayJobInfo
@@ -407,7 +410,10 @@ func (r *RayDashboardClient) StopJob(ctx context.Context, jobName string) (err e
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp.Body, maxDashboardResponseBodyBytes)
+	if err != nil {
+		return fmt.Errorf("StopJob fail: %w", err)
+	}
 
 	var jobStopResp RayJobStopResponse
 	if err = json.Unmarshal(body, &jobStopResp); err != nil {
@@ -425,6 +431,18 @@ func (r *RayDashboardClient) StopJob(ctx context.Context, jobName string) (err e
 		}
 	}
 	return nil
+}
+
+func readLimitedBody(body io.Reader, limit int64) ([]byte, error) {
+	limitedReader := io.LimitReader(body, limit+1)
+	responseBody, err := io.ReadAll(limitedReader)
+	if err != nil && !stdErrors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if int64(len(responseBody)) > limit {
+		return nil, fmt.Errorf("response body exceeds limit of %d bytes", limit)
+	}
+	return responseBody, nil
 }
 
 func (r *RayDashboardClient) DeleteJob(ctx context.Context, jobName string) error {

--- a/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
+++ b/ray-operator/controllers/ray/utils/dashboard_httpclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
@@ -170,5 +171,33 @@ var _ = Describe("RayFrameworkGenerator", func() {
 
 		err := rayDashboardClient.StopJob(context.TODO(), "stop-job-1")
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Test GetJobInfo response too large", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder("GET", rayDashboardClient.dashboardURL+JobPath+"large-job",
+			func(_ *http.Request) (*http.Response, error) {
+				largeBody := strings.Repeat("a", int(maxDashboardResponseBodyBytes+1))
+				return httpmock.NewStringResponse(200, largeBody), nil
+			})
+
+		_, err := rayDashboardClient.GetJobInfo(context.TODO(), "large-job")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("response body exceeds limit"))
+	})
+
+	It("Test StopJob response too large", func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder("POST", rayDashboardClient.dashboardURL+JobPath+"large-stop-job/stop",
+			func(_ *http.Request) (*http.Response, error) {
+				largeBody := strings.Repeat("a", int(maxDashboardResponseBodyBytes+1))
+				return httpmock.NewStringResponse(200, largeBody), nil
+			})
+
+		err := rayDashboardClient.StopJob(context.TODO(), "large-stop-job")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("response body exceeds limit"))
 	})
 })

--- a/ray-operator/controllers/ray/utils/validation.go
+++ b/ray-operator/controllers/ray/utils/validation.go
@@ -153,9 +153,6 @@ func ValidateRayJobSpec(rayJob *rayv1.RayJob) error {
 	}
 
 	isClusterSelectorMode := len(rayJob.Spec.ClusterSelector) != 0
-	if rayJob.Spec.Suspend && isClusterSelectorMode {
-		return fmt.Errorf("the ClusterSelector mode doesn't support the suspend operation")
-	}
 	if rayJob.Spec.RayClusterSpec == nil && !isClusterSelectorMode {
 		return fmt.Errorf("one of RayClusterSpec or ClusterSelector must be set")
 	}

--- a/ray-operator/controllers/ray/utils/validation_test.go
+++ b/ray-operator/controllers/ray/utils/validation_test.go
@@ -737,15 +737,15 @@ func TestValidateRayJobSpec(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "the ClusterSelector mode doesn't support the suspend operation",
+			name: "clusterSelector RayJob may be suspended when shutdownAfterJobFinishes is true",
 			spec: rayv1.RayJobSpec{
 				Suspend:                  true,
 				ShutdownAfterJobFinishes: true,
 				ClusterSelector: map[string]string{
-					"key": "value",
+					"ray.io/cluster": "my-cluster",
 				},
 			},
-			expectError: true,
+			expectError: false,
 		},
 		{
 			name: "failed to unmarshal RuntimeEnvYAML",


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Why are these changes needed?

- RayJobs that use **`clusterSelector`** (run on an existing RayCluster) previously could not suspend in a useful way: suspend was built around deleting a RayJob-owned cluster, which does not apply when the cluster is shared. **`spec.suspend` was effectively ignored** and the Ray workload could keep running.

- This change **stops the Ray job via the Ray Dashboard Jobs API** (`StopJob` → `POST .../api/jobs/{id}/stop`) when suspending a **`clusterSelector`** RayJob, **without deleting the cluster**. It clears the submission id and uses the existing resume path (**`Suspended` → `New`**) so the job can be submitted again. Validation is updated in **`utils.ValidateRayJobSpec`** so **`clusterSelector` + `suspend`** is allowed when **`shutdownAfterJobFinishes`** is true (same rule as other RayJobs). The dashboard client is initialised with the current **`InitClient(ctx, url, rayCluster)`** API after loading the target RayCluster.

New Features
- RayJob suspension via cluster selector is now supported, stopping jobs via the cluster dashboard, cleaning up submitter jobs, and updating job status accordingly.

Bug Fixes
- Improved validation and suspension handling so cluster-selector-managed jobs transition to Suspended/Stopped correctly without deleting cluster resources or leaving inconsistent status.

## Related issue number

Closes [RHOAIENG-60157](https://redhat.atlassian.net/browse/RHOAIENG-60157)

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * RayJob cluster-selector mode now suspends jobs via the Ray dashboard API instead of deleting Ray cluster resources, preserving compute infrastructure during suspension.
  * Added bounded memory-safe handling for dashboard API responses to prevent unbounded resource exhaustion.

* **Tests**
  * Updated validation tests to reflect new cluster-selector suspension behavior.
  * Added tests for handling oversized dashboard API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->