### PR TITLE
RHOAIENG-57443: Permissive head NetworkPolicy egress for default-deny

### DIFF
--- a/ray-operator/controllers/ray/networkpolicy_controller.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller.go
@@ -343,6 +343,15 @@ func (r *NetworkPolicyController) buildHeadNetworkPolicy(ctx context.Context, in
 		})
 	}
 
+	// Declaring PolicyTypeEgress ensures this NetworkPolicy overrides any namespace-level default-deny
+	// egress policy. An allow-all egress rule is used rather than enumerating specific destinations
+	// because the head pod's egress requirements are platform-dependent (DNS, Kubernetes API, workers,
+	// node-local services, platform-specific OVN/SDN paths, etc.). The primary security boundary for
+	// the head pod is the ingress rules above.
+	egressRules := []networkingv1.NetworkPolicyEgressRule{
+		{},
+	}
+
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-head", instance.Name),
@@ -356,8 +365,12 @@ func (r *NetworkPolicyController) buildHeadNetworkPolicy(ctx context.Context, in
 					utils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
 				},
 			},
-			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
-			Ingress:     ingressRules,
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: ingressRules,
+			Egress:  egressRules,
 		},
 	}
 }

--- a/ray-operator/controllers/ray/networkpolicy_controller_test.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller_test.go
@@ -142,8 +142,15 @@ var _ = Context("NetworkPolicy Controller Integration Tests", func() {
 			Expect(headNetworkPolicy.OwnerReferences[0].Name).To(Equal(rayCluster.Name))
 			Expect(headNetworkPolicy.OwnerReferences[0].Kind).To(Equal("RayCluster"))
 
-			// Verify policy type
-			Expect(headNetworkPolicy.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}))
+			// Verify policy types (egress declared so this policy overrides any default-deny)
+			Expect(headNetworkPolicy.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			}))
+			// Single allow-all egress rule
+			Expect(headNetworkPolicy.Spec.Egress).To(HaveLen(1))
+			Expect(headNetworkPolicy.Spec.Egress[0].Ports).To(BeEmpty())
+			Expect(headNetworkPolicy.Spec.Egress[0].To).To(BeEmpty())
 
 			// Verify pod selector targets head pods only
 			expectedPodSelector := metav1.LabelSelector{

--- a/ray-operator/controllers/ray/networkpolicy_controller_unit_test.go
+++ b/ray-operator/controllers/ray/networkpolicy_controller_unit_test.go
@@ -154,8 +154,16 @@ func TestBuildHeadNetworkPolicy_BasicCluster(t *testing.T) {
 	}
 	assert.Equal(t, expectedLabels, policy.Labels)
 
-	// Verify policy type
-	assert.Equal(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}, policy.Spec.PolicyTypes)
+	// Verify policy types (egress required so this policy overrides any default-deny)
+	assert.Equal(t, []networkingv1.PolicyType{
+		networkingv1.PolicyTypeIngress,
+		networkingv1.PolicyTypeEgress,
+	}, policy.Spec.PolicyTypes)
+
+	// Single allow-all egress rule (empty rule = allow all destinations/ports)
+	require.Len(t, policy.Spec.Egress, 1)
+	assert.Empty(t, policy.Spec.Egress[0].Ports)
+	assert.Empty(t, policy.Spec.Egress[0].To)
 
 	// Verify pod selector targets head pods only
 	expectedPodSelector := metav1.LabelSelector{


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Why are these changes needed?

When the `odh.ray.io/secure-trusted-network` annotation is enabled, the head pod's NetworkPolicy previously only declared `PolicyTypeIngress`. In clusters that also apply a namespace-level default-deny egress policy, this meant the head pod's outbound traffic was blocked — preventing the Ray autoscaler sidecar from reaching the Kubernetes API server, DNS, and worker pods, causing autoscaling to fail.

This change adds `PolicyTypeEgress` to the head NetworkPolicy with a single allow-all egress rule. A permissive egress rule is used rather than enumerating specific destinations because the head pod's egress requirements are platform-dependent (DNS, Kubernetes API, workers, node-local services, platform-specific OVN/SDN paths, etc.). The primary security boundary for the head pod remains the ingress rules.

## Related issue number

Closes [RHOAIENG-57443](https://redhat.atlassian.net/browse/RHOAIENG-57443)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

### Manual testing performed

- Deployed custom operator build to an OpenShift cluster with network policies enabled (no Kueue)
- Verified the head NetworkPolicy is generated with `policyTypes: ["Ingress", "Egress"]` and `egress: [{}]` automatically from the annotation — no manual editing required
- Confirmed the head pod can reach the Kubernetes API server and resolve DNS through the egress rule
- Confirmed the autoscaler sidecar starts, connects to GCS and the Kubernetes API, and runs update iterations successfully

## Summary by CodeRabbit

* **New Features**
  * Head NetworkPolicy now includes both ingress and egress; egress is configured as a single allow-all rule (no port or peer restrictions).
* **Tests**
  * Unit and controller tests updated to verify the head NetworkPolicy declares ingress and egress and that the egress rule permits all destinations/ports.