### PR TITLE
RHOAIENG-63722: Make kube-rbac-proxy image configurable via env var

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -66,6 +66,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
+            value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
           # If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
           # If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
           # Warning: we highly recommend setting to true and let kuberay handle for you.

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,11 +54,33 @@ const (
 
 	oauthConfigVolumeName = "oauth-config"
 
-	oidcProxyContainerName  = "kube-rbac-proxy"
-	oidcProxyPortName       = "https"
-	oauthProxyImage         = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
-	oidcProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
+	oidcProxyContainerName = "kube-rbac-proxy"
+	oidcProxyPortName      = "https"
+	oauthProxyImage        = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+
+	// defaultOIDCProxyContainerImage is the fallback image used when no RELATED_IMAGE_*
+	// env var is set. Must match an entry in the RHOAI CSV relatedImages so it is
+	// mirrored correctly in disconnected environments.
+	defaultOIDCProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
 )
+
+// oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
+// init() from the operator's env vars so that disconnected installs can override
+// the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE (set in manager.yaml and
+// substituted by the deployer from the RHOAI CSV relatedImages at install time).
+var oidcProxyContainerImage = defaultOIDCProxyContainerImage
+
+func init() {
+	for _, envVar := range []string{
+		"RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE",
+		"RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+	} {
+		if image := strings.TrimSpace(os.Getenv(envVar)); image != "" {
+			oidcProxyContainerImage = image
+			return
+		}
+	}
+}
 
 // AuthenticationController is a completely independent controller that watches authentication-related
 // resources (ConfigMaps, ServiceAccounts, OpenShift Routes) and manages authentication configurations for Ray clusters on Openshift.


### PR DESCRIPTION
## RHOAIENG-63699: Make kube-rbac-proxy image configurable via env var

### Problem

The `ose-kube-rbac-proxy` sidecar image injected into RayCluster head pods
was hardcoded as a constant in `authentication_controller.go`:

```go
oidcProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828..."
```

This made the image unavailable in disconnected environments where OLM manages
image availability via CSV `relatedImages`. Even though the correct image
(`registry.redhat.io/rhoai/odh-kube-auth-proxy-rhel9`) is listed in the RHOAI
CSV `relatedImages` under the name `odh_kube_auth_proxy_image`, there was no
mechanism for the operator to pick it up at runtime.

### Changes

**`ray-operator/controllers/ray/authentication_controller.go`**

- Changed `oidcProxyContainerImage` from a `const` to a `var`, with
  `defaultOIDCProxyContainerImage` as the hardcoded fallback (unchanged image,
  no default behaviour change)
- Added `init()` that reads from `RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE`
  (primary) and `RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE` (secondary) — both
  names match entries in the RHOAI CSV `relatedImages` by convention
- If neither env var is set, falls back to `defaultOIDCProxyContainerImage`
  (`11828...`) — identical to the previous hardcoded behaviour

**`ray-operator/config/manager/manager.yaml`**

- Added `RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE` env var to the
  kuberay-operator deployment spec, set to the existing known-good image
  (`11828...`) as the shipped default
- The env var name follows the `RELATED_IMAGE_*` convention so any deployer
  (OLM, opendatahub-operator, CI) can substitute it with the correct mirrored
  digest at install time without code changes

### How it works

```
manager.yaml env var (default: 11828...)
    ↓ deployer overrides with CSV image at install time (e.g. 50ccc...)
kuberay-operator pod env: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE=<image>
    ↓ init() reads it at startup
oidcProxyContainerImage = <image>
    ↓ GetOIDCProxySidecar() uses it
kube-rbac-proxy sidecar in RayCluster head pod = <image>
```

### Verification

Verified on an OpenShift cluster with RHOAI installed and Ray set to `Removed`
in the DSC (custom kustomize deployment of the operator):

1. Confirmed `RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE` is present on the
   operator pod with the default image value
2. Created a RayCluster with `odh.ray.io/secure-trusted-network: "true"` to
   trigger sidecar injection
3. Confirmed the `kube-rbac-proxy` sidecar in the head pod uses the image from
   the env var
4. Manually overrode the env var to a different image digest and confirmed the
   sidecar picked up the new value — proving the env var path is live

### Limitation / follow-up

Full end-to-end verification of the disconnected install path requires Ray to
be in `Managed` state in the DSC so the opendatahub-operator deploys kuberay
and propagates `RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE` from its own
environment (populated by OLM from the CSV `relatedImages`). This was not
testable in the current setup since the operator was deployed via kustomize
directly (Ray set to `Removed`). A companion change to
`opendatahub-operator/internal/controller/components/ray/ray_support.go` to
add `odh-kube-auth-proxy-image` to `imageParamMap` would complete the
propagation chain automatically.

Closes RHOAIENG-63699

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The operator now supports environment variable configuration for OIDC proxy container images, enabling seamless deployment in air-gapped and offline environments with custom image registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->