### PR TITLE
fix: use rh registry go image

### DIFF
--- a/ray-operator/Dockerfile.rhoai
+++ b/ray-operator/Dockerfile.rhoai
@@ -1,5 +1,5 @@
 # Build the manager binary - we don't have a registry ubi9 toolset for go1.24 yet
-FROM golang:1.24.2-bullseye AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.26-1779467716 AS builder
 
 
 WORKDIR /workspace

--- a/ray-operator/Dockerfile.rhoai
+++ b/ray-operator/Dockerfile.rhoai
@@ -1,5 +1,5 @@
 # Build the manager binary - we don't have a registry ubi9 toolset for go1.24 yet
-FROM registry.redhat.io/ubi9/go-toolset:1.26-1779467716 AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:570ebf7fd7809394f10deaa27bc5b80e31891c17f10e95fe6b587e4eea7be790 AS builder
 
 
 WORKDIR /workspace


### PR DESCRIPTION
## Why are these changes needed?

fix: use rh registry go image

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build infrastructure to use Red Hat UBI Go toolset image for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->