### PR TITLE
RHOAIENG-61476: Tier 2 Scaffolding

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/format-go.sh",
+        "matcher": "\\.go$"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/block-dangerous.sh",
+        "failClosed": true
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block-dangerous.sh
+++ b/.cursor/hooks/block-dangerous.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+command_str=$(echo "$input" | jq -r '.command // empty')
+
+if echo "$command_str" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f\b'; then
+  echo '{
+    "permission": "deny",
+    "user_message": "Force-push blocked by project hook. Use a normal push or override manually.",
+    "agent_message": "Hook denied force-push. Do not retry with --force."
+  }'
+  exit 0
+fi
+
+if echo "$command_str" | grep -qE '\brm\s+-[a-zA-Z]*r[a-zA-Z]*f\b|\brm\s+-[a-zA-Z]*f[a-zA-Z]*r\b'; then
+  echo '{
+    "permission": "deny",
+    "user_message": "rm -rf blocked by project hook. Remove files individually or override manually.",
+    "agent_message": "Hook denied rm -rf. Use targeted file removal instead."
+  }'
+  exit 0
+fi
+
+echo '{ "permission": "allow" }'
+exit 0

--- a/.cursor/hooks/format-go.sh
+++ b/.cursor/hooks/format-go.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+file=$(echo "$input" | jq -r '.path // empty')
+
+if [[ -z "$file" || ! -f "$file" || "$file" != *.go ]]; then
+  exit 0
+fi
+
+if command -v gofumpt &>/dev/null; then
+  gofumpt -w "$file"
+elif command -v gofmt &>/dev/null; then
+  gofmt -s -w "$file"
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,50 @@ This is a multi-module repo with three main Go modules:
 
 When making changes, run `go mod tidy` in the relevant module directory.
 
+## Pattern References
+
+Real examples for the most common change types. Follow these patterns, not descriptions.
+
+### Adding a new CRD field
+
+See `AuthenticationReady` in `ray-operator/apis/ray/v1/raycluster_types.go` (line 294).
+Pattern: add a typed constant or struct field with a godoc comment, wire it into
+the controller, then add an e2e test. After changing types, regenerate:
+
+```sh
+cd ray-operator && make manifests generate
+```
+
+### Adding or modifying a controller reconciler
+
+See `RayClusterReconciler.Reconcile` in `ray-operator/controllers/ray/raycluster_controller.go`
+(line 124). The thin `Reconcile` method fetches the CR and delegates to `rayClusterReconcile`
+(line 163), which calls sub-reconcilers (`reconcilePods`, `reconcileHeadService`, etc.).
+New reconciliation logic goes in a sub-reconciler, not inline in the top-level method.
+
+### Adding an e2e test
+
+See `TestRayJob` in `ray-operator/test/e2e/rayjob_test.go` (line 18).
+Pattern: `test := With(t)` for support helpers, `test.NewTestNamespace()` for isolation,
+apply resources via `test.Client().Core()...Apply(...)`, assert with `Eventually` +
+Gomega. Support helpers live in `ray-operator/test/support/`.
+
+### Midstream carry patch
+
+See commit `17fbd87` — `CARRY: task(RHOAIENG-59432): fix RoleBinding for autoscaling`.
+Pattern: `CARRY:` prefix, Jira key in subject, scoped to the minimum diff. Carries are
+upstream-unmergeable fixes specific to RHOAI/ODH. They touch controller logic, RBAC,
+and corresponding unit tests.
+
+### Kustomize overlay or webhook change
+
+- **Webhook**: `ray-operator/pkg/webhooks/v1/raycluster_mutating_webhook.go` — OpenShift-
+  specific defaults (e.g. enforce `EnableSecureTrustedNetwork`, disable `EnableIngress`).
+  Unit tests are adjacent: `raycluster_mutating_webhook_unit_test.go`.
+- **Kustomize**: `ray-operator/config/openshift/kustomization.yaml` — composes `../default`,
+  adds `webhook.yaml`, and applies patches like `webhook-deployment-patch.yaml` and
+  `kuberay-operator-image-patch.yaml`.
+
 ## Documentation
 
 User-facing docs: <https://docs.ray.io/en/latest/cluster/kubernetes/>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,25 @@ custom resources. Go-based operator using Kubebuilder framework.
 | `config/` | Operator configuration and CRD manifests |
 | `scripts/` | Build and utility scripts |
 
+### Where to Make Changes
+
+| Task | Location |
+|---|---|
+| CRD types (RayCluster, RayJob, RayService) | `ray-operator/apis/ray/v1/` |
+| Controller reconciliation logic | `ray-operator/controllers/ray/` |
+| Webhooks (validation and defaulting) | `ray-operator/pkg/webhooks/v1/` |
+| E2e tests | `ray-operator/test/e2e/`, `ray-operator/test/e2eautoscaler/`, `ray-operator/test/e2eupgrade/`, `ray-operator/test/e2erayservice/` |
+| Unit tests | Adjacent `*_test.go` or `*_unit_test.go` next to source |
+| E2e test helpers | `ray-operator/test/support/` |
+| Kustomize overlays (OpenShift/midstream) | `ray-operator/config/openshift/` |
+| Kustomize base (CRDs, RBAC, webhook) | `ray-operator/config/default/`, `ray-operator/config/crd/`, `ray-operator/config/rbac/`, `ray-operator/config/webhook/` |
+| Generated clients (clientset, apply configs) | `ray-operator/pkg/client/` |
+| CI workflows | `.github/workflows/` |
+| Codegen scripts | `ray-operator/hack/`, then `make manifests generate` |
+| Midstream Makefile (e2e image builds) | Root `Makefile` |
+| Pre-commit config | `.pre-commit-config.yaml` |
+| Linter config | `.golangci.yml` |
+
 ## Build and Test Commands
 
 ```sh
@@ -142,7 +161,7 @@ Real examples for the most common change types. Follow these patterns, not descr
 
 ### Adding a new CRD field
 
-See `AuthenticationReady` in `ray-operator/apis/ray/v1/raycluster_types.go` (line 294).
+See `AuthenticationReady` in `ray-operator/apis/ray/v1/raycluster_types.go`.
 Pattern: add a typed constant or struct field with a godoc comment, wire it into
 the controller, then add an e2e test. After changing types, regenerate:
 
@@ -152,21 +171,21 @@ cd ray-operator && make manifests generate
 
 ### Adding or modifying a controller reconciler
 
-See `RayClusterReconciler.Reconcile` in `ray-operator/controllers/ray/raycluster_controller.go`
-(line 124). The thin `Reconcile` method fetches the CR and delegates to `rayClusterReconcile`
-(line 163), which calls sub-reconcilers (`reconcilePods`, `reconcileHeadService`, etc.).
+See `RayClusterReconciler.Reconcile` in `ray-operator/controllers/ray/raycluster_controller.go`.
+The thin `Reconcile` method fetches the CR and delegates to `rayClusterReconcile`,
+which calls sub-reconcilers (`reconcilePods`, `reconcileHeadService`, etc.).
 New reconciliation logic goes in a sub-reconciler, not inline in the top-level method.
 
 ### Adding an e2e test
 
-See `TestRayJob` in `ray-operator/test/e2e/rayjob_test.go` (line 18).
+See `TestRayJob` in `ray-operator/test/e2e/rayjob_test.go`.
 Pattern: `test := With(t)` for support helpers, `test.NewTestNamespace()` for isolation,
 apply resources via `test.Client().Core()...Apply(...)`, assert with `Eventually` +
 Gomega. Support helpers live in `ray-operator/test/support/`.
 
 ### Midstream carry patch
 
-See commit `17fbd87` — `CARRY: task(RHOAIENG-59432): fix RoleBinding for autoscaling`.
+See `CARRY: task(RHOAIENG-59432): fix RoleBinding for autoscaling`.
 Pattern: `CARRY:` prefix, Jira key in subject, scoped to the minimum diff. Carries are
 upstream-unmergeable fixes specific to RHOAI/ODH. They touch controller logic, RBAC,
 and corresponding unit tests.


### PR DESCRIPTION
## Why are these changes needed?

Implements Tier 2 repo scaffolding best practices for kuberay (midstream),
per [RHOAIENG-61476](https://redhat.atlassian.net/browse/RHOAIENG-61476) and the Agentic SDLC guidelines
**2.1 — Pattern references:** Added 5 pattern references to CLAUDE.md covering
CRD fields, controller logic, e2e tests, carry patches, and Kustomize overlays.

**2.2 — Starter hooks:** Added Cursor hooks for auto-formatting (gofmt/goimports)
and blocking dangerous operations (force-push, rm -rf).

**2.5 — Predictable file organization:** Added directory layout lookup table
to CLAUDE.md.

Items 2.3 (design intent) and 2.4 (type annotations) are N/A for kuberay — Go
is statically typed, and design intent for the upstream operator is tracked
upstream at ray-project/kuberay.

## Related issue number

[RHOAIENG-61476](https://redhat.atlassian.net/browse/RHOAIENG-61476)

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] Testing is not required for this change

Note: CI checks are SKIPPED because this PR only modifies `.cursor/` config
files and `CLAUDE.md` — no Go code changes trigger the build/lint/test workflows.
This is expected behavior from the path-filtered CI configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated Go code formatting to run after edits.
  * Added safety checks that block dangerous operations (e.g., force pushes and forceful recursive deletions) during workflow execution.

* **Documentation**
  * Added contributor guidance describing where to make changes and common patterns for making and testing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->