### PR TITLE
RHOAIENG-63113: Add operator-chaos shift-left validation for KubeRay

### DIFF
--- a/.github/workflows/operator-chaos.yml
+++ b/.github/workflows/operator-chaos.yml
@@ -1,0 +1,146 @@
+name: Operator Chaos
+
+on:
+  pull_request:
+    paths:
+      - "ray-operator/apis/**"
+      - "ray-operator/config/crd/**"
+      - "ray-operator/controllers/**"
+      - "ray-operator/cmd/**"
+      - "chaos/knowledge/**"
+      - ".github/workflows/operator-chaos.yml"
+
+permissions:
+  contents: read
+
+env:
+  OPERATOR_CHAOS_VERSION: "9e6ac9668b9aaca2f0f2ddf169867862b7925b80"
+
+jobs:
+  operator-chaos:
+    name: Operator Chaos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: ray-operator/go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            ray-operator/config/crd/bases/
+          sparse-checkout-cone-mode: false
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge "chaos/knowledge/kuberay.yaml"
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "chaos/knowledge/kuberay.yaml" --local
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/kuberay.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff Ray CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_crd_dir="base-branch/ray-operator/config/crd/bases"
+          target_crd_dir="ray-operator/config/crd/bases"
+          if [[ ! -d "${source_crd_dir}" || ! -d "${target_crd_dir}" ]]; then
+            echo "Base or current Ray CRD directory not found; skipping CRD diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          source_dir="${output_dir}/source-crds"
+          target_dir="${output_dir}/target-crds"
+          crd_diff_json="${output_dir}/crd-diff.json"
+          rm -rf "${source_dir}" "${target_dir}"
+          mkdir -p "${source_dir}" "${target_dir}"
+          cp "${source_crd_dir}"/*.yaml "${source_dir}/"
+          cp "${target_crd_dir}"/*.yaml "${target_dir}/"
+
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}" \
+            --format json > "${crd_diff_json}"
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}"
+
+          crd_breaking=$(jq -r '
+            reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+          ' "${crd_diff_json}")
+          if (( crd_breaking > 0 )); then
+            echo "operator-chaos detected ${crd_breaking} breaking CRD schema change(s)."
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/kuberay.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --dry-run

--- a/chaos/knowledge/kuberay.yaml
+++ b/chaos/knowledge/kuberay.yaml
@@ -69,7 +69,8 @@ components:
         type: mutating
         path: /mutate-ray-io-v1-raycluster
     finalizers:
-      - ray.io/finalizer
+      - ray.io/gcs-ft-redis-cleanup-finalizer
+      - ray.io/rayjob-finalizer
     steadyState:
       checks:
         - type: conditionTrue

--- a/chaos/knowledge/kuberay.yaml
+++ b/chaos/knowledge/kuberay.yaml
@@ -1,0 +1,85 @@
+operator:
+  name: ray
+  namespace: redhat-ods-applications
+  repository: https://github.com/opendatahub-io/kuberay
+
+components:
+  - name: kuberay-operator
+    controller: KubeRayOperator
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: kuberay-operator
+        namespace: redhat-ods-applications
+        labels:
+          app.kubernetes.io/name: kuberay
+          app.kubernetes.io/component: kuberay-operator
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kuberay-operator
+        namespace: redhat-ods-applications
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kuberay-operator
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kuberay-operator
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kuberay-operator-gateway-api
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kuberay-operator-gateway-api
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kuberay-operator-configmap
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kuberay-operator-configmap
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: kuberay-operator-leader-election
+        namespace: redhat-ods-applications
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: kuberay-operator-leader-election
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: ray-operator-leader
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Service
+        name: kuberay-operator
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Service
+        name: kuberay-webhook-service
+        namespace: redhat-ods-applications
+      - apiVersion: admissionregistration.k8s.io/v1
+        kind: MutatingWebhookConfiguration
+        name: kuberay-mutating-webhook-configuration
+      - apiVersion: security.openshift.io/v1
+        kind: SecurityContextConstraints
+        name: run-as-ray-user
+    webhooks:
+      - name: mraycluster.kb.io
+        type: mutating
+        path: /mutate-ray-io-v1-raycluster
+    finalizers:
+      - ray.io/finalizer
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kuberay-operator
+          namespace: redhat-ods-applications
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10


### PR DESCRIPTION
## Why are these changes needed?

PRs that modify KubeRay CRD schemas, API types, or controller logic currently have no automated check for breaking upgrade changes. Every other GA component in RHOAI (model-registry-operator, mlflow-operator) has already been onboarded to operator-chaos shift-left validation. This PR adds the same for KubeRay, covering L1 (breaking change detection) and L2 (knowledge model).

The GHA workflow validates the knowledge model, runs preflight checks, diffs both the knowledge model and all 3 CRD schemas (RayCluster, RayJob, RayService) between base and PR branches, and previews upgrade simulation. It only triggers on PRs touching relevant paths (`ray-operator/apis/`, `ray-operator/config/crd/`, `ray-operator/controllers/`, etc.).

The knowledge model describes the operator's control-plane topology — 15 managed resources including Deployment, ServiceAccount, RBAC, Lease, Services, SCC, and MutatingWebhookConfiguration. Resource names were verified against a running RHOAI 3.3.x cluster.

## Related issue number

Closes [RHOAIENG-63113](https://redhat.atlassian.net/browse/RHOAIENG-63113)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [x] Manual tests
  - [ ] This PR is not tested :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated validation workflow for operator changes that checks schema compatibility and runs upgrade simulations.
  * Added KubeRay chaos testing configuration to validate operator deployment behavior, steady-state checks, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->