### PR TITLE
Add supply-chain security controls (FIND-014)

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -27,12 +27,20 @@ jobs:
         directory:
           - .
           - ray-operator
+    env:
+      GOTOOLCHAIN: local
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version-input: '1.24'
-          work-dir: ${{ matrix.directory }}
+          go-version: '1.24'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck
+        working-directory: ${{ matrix.directory }}
+        run: govulncheck ./...

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -16,22 +16,23 @@ permissions:
 
 jobs:
   govulncheck:
-    name: Go vulnerability check
+    name: govulncheck (${{ matrix.directory }})
     runs-on: ubuntu-22.04
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        directory:
+          - .
+          - ray-operator
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
       - name: Run govulncheck
-        run: ./scripts/govulncheck.sh
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: '1.24'
+          work-dir: ${{ matrix.directory }}

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,37 @@
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - dev
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '45 7 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Go vulnerability check
+    runs-on: ubuntu-22.04
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: ./scripts/govulncheck.sh

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - dev
+  schedule:
+    - cron: '30 7 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,117 @@
+name: Trivy Container Scan
+
+on:
+  push:
+    branches:
+      - dev
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '15 6 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan-operator:
+    name: Scan Operator Image
+    runs-on: ubuntu-22.04
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Operator image
+        run: |
+          docker build -t kuberay/operator:scan \
+            -f ray-operator/Dockerfile \
+            ray-operator/
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.28.0
+        with:
+          image-ref: 'kuberay/operator:scan'
+          format: 'sarif'
+          output: 'operator-trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'operator-trivy-results.sarif'
+          category: 'trivy-operator'
+
+  scan-apiserver:
+    name: Scan APIServer Image
+    runs-on: ubuntu-22.04
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build APIServer image
+        run: |
+          docker build -t kuberay/apiserver:scan \
+            -f apiserver/Dockerfile .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.28.0
+        with:
+          image-ref: 'kuberay/apiserver:scan'
+          format: 'sarif'
+          output: 'apiserver-trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'apiserver-trivy-results.sarif'
+          category: 'trivy-apiserver'
+
+  scan-dashboard:
+    name: Scan Dashboard Image
+    runs-on: ubuntu-22.04
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Dashboard image
+        run: |
+          docker build -t kuberay/dashboard:scan \
+            -f dashboard/Dockerfile \
+            dashboard/
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.28.0
+        with:
+          image-ref: 'kuberay/dashboard:scan'
+          format: 'sarif'
+          output: 'dashboard-trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'dashboard-trivy-results.sarif'
+          category: 'trivy-dashboard'

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -35,7 +35,7 @@ jobs:
             ray-operator/
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'kuberay/operator:scan'
           format: 'sarif'
@@ -68,7 +68,7 @@ jobs:
             -f apiserver/Dockerfile .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'kuberay/apiserver:scan'
           format: 'sarif'
@@ -102,7 +102,7 @@ jobs:
             dashboard/
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'kuberay/dashboard:scan'
           format: 'sarif'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,16 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+      - id: govulncheck
+        name: govulncheck
+        entry: ./scripts/govulncheck.sh
+        types: [go]
+        language: golang
+        require_serial: true
+        always_run: true
+        pass_filenames: false
+        additional_dependencies:
+          - golang.org/x/vuln/cmd/govulncheck@latest
       - id: generate-crd-schema
         name: generate CRD schemas for use of kubeconform
         entry: ./scripts/generate-crd-schema.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,16 +47,6 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
-      - id: govulncheck
-        name: govulncheck
-        entry: ./scripts/govulncheck.sh
-        types: [go]
-        language: golang
-        require_serial: true
-        always_run: true
-        pass_filenames: false
-        additional_dependencies:
-          - golang.org/x/vuln/cmd/govulncheck@latest
       - id: generate-crd-schema
         name: generate CRD schemas for use of kubeconform
         entry: ./scripts/generate-crd-schema.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this Red Hat fork of KubeRay,
+please report it through **Red Hat Product Security**:
+
+- **Email:** [secalert@redhat.com](mailto:secalert@redhat.com)
+- **PGP Key:** <https://access.redhat.com/security/team/key/>
+- **Security Advisories:** <https://access.redhat.com/security/updates/>
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Red Hat Product Security will acknowledge your report, coordinate the fix, and
+handle disclosure.
+
+## Upstream Vulnerabilities
+
+For vulnerabilities in the upstream KubeRay project (not specific to this fork),
+please follow the [upstream reporting process](https://github.com/ray-project/kuberay/security).
+
+## Supported Versions
+
+Security fixes are applied to the actively maintained release branches of this
+fork. For details on which versions are currently supported, refer to the
+[Red Hat OpenShift AI life cycle](https://access.redhat.com/support/policy/updates/rhoai/lifecycle).

--- a/scripts/govulncheck.sh
+++ b/scripts/govulncheck.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run govulncheck at each Go module root.
+# Root module covers: apiserver, kubectl-plugin, apiserversdk
+# ray-operator has its own module.
+module_roots=". ray-operator"
+
+for dir in $module_roots; do
+  echo "Running govulncheck in ${dir}..."
+  pushd "$dir"
+  govulncheck ./...
+  popd
+done


### PR DESCRIPTION
Address security audit finding FIND-014 (CWE-1395) by adding:
- SECURITY.md pointing to Red Hat Product Security (secalert@redhat.com)
- govulncheck pre-commit hook for Go vulnerability scanning
- OpenSSF Scorecard GitHub Actions workflow for supply-chain scoring
- Trivy container image scanning workflow for operator, apiserver, and dashboard

gosec is already covered via golangci-lint and requires no additional changes.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated container vulnerability scanning for components with CRITICAL and HIGH severity filtering
  * Added OpenSSF security scorecard analysis for ongoing security assessment

* **Documentation**
  * Added security policy detailing vulnerability reporting procedures and security fix timelines

* **Chores**
  * Enhanced development tooling with Go vulnerability scanning in pre-commit hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->