### PR TITLE
RHOAIENG-63699: integrate kube-rbac-proxy image with ODH operator ima…

### DIFF
--- a/ray-operator/config/manager/manager.yaml
+++ b/ray-operator/config/manager/manager.yaml
@@ -66,8 +66,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE
-            value: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
           # If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
           # If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
           # Warning: we highly recommend setting to true and let kuberay handle for you.

--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -19,3 +19,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # kube-rbac-proxy sidecar image for authentication controller.
+        # Value comes from params.env (odh-kube-rbac-proxy-image), overridden at deploy
+        # time by the ODH/RHOAI operator via imageParamMap
+        # (RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE). Read at startup by init() in
+        # authentication_controller.go.
+        - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
+          value: $(odh-kube-rbac-proxy-image)

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -26,6 +26,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.odh-kuberay-operator-controller-image
+- name: odh-kube-rbac-proxy-image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kube-rbac-proxy-image
 
 resources:
 - ray_operator_scc.yaml

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,2 +1,3 @@
 namespace=opendatahub
 odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.4
+odh-kube-rbac-proxy-image=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -69,8 +69,9 @@ const (
 
 // oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
 // init() from the operator's env vars so that disconnected installs can override
-// the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE (set in manager.yaml and
-// substituted by the deployer from the RHOAI CSV relatedImages at install time).
+// the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE or
+// RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via the openshift
+// overlay and substituted by the ODH/RHOAI operator from CSV relatedImages).
 var oidcProxyContainerImage = defaultOIDCProxyContainerImage
 
 var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not found yet")


### PR DESCRIPTION
…ge override flow

The existing RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE env var in manager.yaml was not connected to the ODH operator's params.env-based image propagation mechanism, so it would never be dynamically overridden in production.

This change:
- Adds odh-kube-auth-proxy-image to params.env with the current default
- Adds a kustomize var referencing the new params.env key
- Injects RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE on the operator deployment via the openshift kustomize overlay using the var
- Removes the hardcoded env var from manager.yaml (non-OpenShift deployments still get the fallback via the Go code default in init())

With this change the ODH operator can override the image at deploy time by adding "odh-kube-auth-proxy-image": "RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE" to imageParamMap in ray_support.go (companion change needed on the ODH operator repo).

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift deployment configuration to better manage the kube-rbac-proxy related image used for authentication.
  * Added a new RBAC proxy image setting to the OpenShift environment via Kustomize variables, with a default value in the OpenShift params file.
  * Removed an outdated related image environment variable from the manager deployment configuration.
* **Documentation**
  * Clarified the authentication controller’s comment about how the proxy image is resolved across OpenShift overlays and substitutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->