### PR TITLE
RHOAIENG-57446: integrate autoscaling tests into tier1 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-test-image:
 	@scripts/update-resources -scenario build-image ray-operator/test/e2e/rayjob_lightweight_test.go
 	@echo "Resource requirements updated successfully using Go AST."
 	# Build the Docker image using podman
-	podman build -f ray-operator/images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
+	podman build --platform linux/amd64 -f ray-operator/images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
 	# Confirm that the resources/ limits were updated
 	@echo "=== Contents of support.go (resource values) ==="
 	@grep -n 'resource\.MustParse(' ray-operator/test/e2e/support.go | grep -E '"(500m|1000m|2000m|1G|3G|6G|10G)"'

--- a/ray-operator/images/tests/run-tests.sh
+++ b/ray-operator/images/tests/run-tests.sh
@@ -55,6 +55,9 @@ if [[ -z "$TEST_TAGS" ]]; then
 fi
 
 REGEX_PARTS=()
+INCLUDE_TIER1=false
+TEST_PACKAGES=("./test/e2e")
+TEST_TIMEOUT="30m"
 
 IFS=',' read -ra TIER_LIST <<< "$TEST_TAGS"
 for TIER in "${TIER_LIST[@]}"; do
@@ -64,8 +67,9 @@ for TIER in "${TIER_LIST[@]}"; do
     [[ -z "$TIER" ]] && continue
     case "$TIER" in
         Tier1)
-            echo "Adding Tier1 kuberay e2e tests"
-            REGEX_PARTS+=("TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode")
+            echo "Adding Tier1 kuberay e2e tests (including autoscaler)"
+            INCLUDE_TIER1=true
+            REGEX_PARTS+=("TestRayJobWithClusterSelector|TestRayJob|TestRayJobSuspend|TestRayJobLightWeightMode|TestRayClusterAutoscaler")
             ;;
         Smoke)
             echo "Adding Smoke kuberay e2e tests (authentication validation)"
@@ -89,8 +93,15 @@ if [[ ${#REGEX_PARTS[@]} -eq 0 ]]; then
     show_usage
 fi
 
+if [[ "$INCLUDE_TIER1" == true ]]; then
+    TEST_PACKAGES+=("./test/e2eautoscaler")
+    TEST_TIMEOUT="60m"
+fi
+
 TEST_RUN_REGEX="^($(IFS='|'; echo "${REGEX_PARTS[*]}"))$"
 echo "Running e2e tests matching: $TEST_RUN_REGEX"
+echo "Running packages: ${TEST_PACKAGES[*]}"
+echo "Test timeout: $TEST_TIMEOUT"
 
 # Run tests with junit XML output
-gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout 30m -run "$TEST_RUN_REGEX" ./test/e2e -p 1 -parallel 1 "${EXTRA_ARGS[@]}"
+gotestsum --format standard-verbose --junitfile results/xunit_report.xml --junitfile-testsuite-name short --junitfile-testcase-classname relative -- -timeout "$TEST_TIMEOUT" -run "$TEST_RUN_REGEX" "${TEST_PACKAGES[@]}" -p 1 -parallel 1 "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
RHOAIENG-57446: integrate autoscaling tests into tier1 tests

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-57446

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated test image builds to use a specific target platform for more consistent build results.
  - Improved test execution handling so Tier 1 runs now include the autoscaler coverage and use longer timeouts when needed.
- **New Features**
  - Added support for selecting test packages and timeouts dynamically based on the requested test tier.
  - Expanded logging to show which test packages and timeout are being used during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->