### PR TITLE
fix: mark webhook TLS secret volume as optional

### DIFF
--- a/ray-operator/config/openshift/webhook-deployment-patch.yaml
+++ b/ray-operator/config/openshift/webhook-deployment-patch.yaml
@@ -24,3 +24,4 @@ spec:
         secret:
           defaultMode: 420
           secretName: kuberay-webhook-server-cert
+          optional: true


### PR DESCRIPTION
## Summary
Mark the `kuberay-webhook-server-cert` secret volume as `optional: true` in the OpenShift webhook deployment patch.

## Problem
The secret is provisioned by OpenShift's service-ca controller when it processes the `service.beta.openshift.io/serving-cert-secret-name` annotation on the webhook Service. If the pod is scheduled before service-ca creates the secret, it fails with:
```
FailedMount: secret "kuberay-webhook-server-cert" not found
```
Observed in nightly smoke tests (RHOAIENG-72306).

## Fix
Adding `optional: true` allows the pod to start without the cert. controller-runtime generates self-signed certs when no cert files are found, and picks up the service-ca cert once it appears.

## Jira
[RHOAIENG-72306](https://issues.redhat.com/browse/RHOAIENG-72306)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the webhook certificate secret mount optional, allowing deployment to continue even when the secret is not yet present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->