### PR TITLE
RHOAIENG-72302: wire oauth-proxy image for disconnected environments

### DIFF
--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -26,3 +26,10 @@ spec:
         # authentication_controller.go.
         - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
           value: $(odh-kube-rbac-proxy-image)
+        # oauth-proxy sidecar image for integrated OAuth authentication.
+        # Value comes from params.env (odh-oauth-proxy-image), overridden at deploy
+        # time by the ODH/RHOAI operator via imageParamMap
+        # (RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE). Read at startup by init() in
+        # authentication_controller.go.
+        - name: RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE
+          value: $(odh-oauth-proxy-image)

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -33,6 +33,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.odh-kube-rbac-proxy-image
+- name: odh-oauth-proxy-image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-oauth-proxy-image
 
 resources:
 - ray_operator_scc.yaml

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,3 +1,4 @@
 namespace=opendatahub
 odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.4
 odh-kube-rbac-proxy-image=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable
+odh-oauth-proxy-image=quay.io/opendatahub/odh-kube-auth-proxy:odh-stable

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -59,13 +59,24 @@ const (
 
 	oidcProxyContainerName = "kube-rbac-proxy"
 	oidcProxyPortName      = "https"
-	oauthProxyImage        = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
+
+	// defaultOAuthProxyImage is the fallback image used when no RELATED_IMAGE_*
+	// env var is set. Must match an entry in the RHOAI CSV relatedImages so it is
+	// mirrored correctly in disconnected environments.
+	defaultOAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bff1326159e0394e169c10575f33025590f5781cb2f1e16dfd5d204b7f7fb4bb"
 
 	// defaultOIDCProxyContainerImage is the fallback image used when no RELATED_IMAGE_*
 	// env var is set. Must match an entry in the RHOAI CSV relatedImages so it is
 	// mirrored correctly in disconnected environments.
 	defaultOIDCProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
 )
+
+// oauthProxyImage holds the resolved oauth-proxy image. Populated by init()
+// from the operator's env vars so that disconnected installs can override the
+// image via RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE (injected on OpenShift via the
+// openshift overlay and substituted by the ODH/RHOAI operator from CSV
+// relatedImages).
+var oauthProxyImage = defaultOAuthProxyImage
 
 // oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
 // init() from the operator's env vars so that disconnected installs can override
@@ -77,6 +88,10 @@ var oidcProxyContainerImage = defaultOIDCProxyContainerImage
 var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not found yet")
 
 func init() {
+	if image := strings.TrimSpace(os.Getenv("RELATED_IMAGE_OSE_OAUTH_PROXY_IMAGE")); image != "" {
+		oauthProxyImage = image
+	}
+
 	for _, envVar := range []string{
 		"RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE",
 		"RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",


### PR DESCRIPTION
## Why are these changes needed?

The `ose-oauth-proxy` image in `authentication_controller.go` was hardcoded with a `:latest` tag and had no `RELATED_IMAGE_*` wiring, blocking disconnected/air-gapped deployments. This wires it using the same kustomize overlay pattern established in #202 for `kube-rbac-proxy`.

## Related issue number

[RHOAIENG-69996](https://redhat.atlassian.net/issues?jql=assignee%20%3D%20currentUser()%20AND%20statusCategory%20!%3D%20done%20AND%20due%20%3C%3D%202026-07-03%20AND%20due%20%3E%3D%202026-06-26&selectedIssue=RHOAIENG-69996)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable OAuth proxy image support via a new deployment parameter, with a default image provided out of the box.
  * The operator now reads an environment-based override at startup to determine the OAuth proxy image used for injected sidecars, improving flexibility during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->