### PR TITLE
RHOAIENG-69996: rename RELATED_IMAGE_OSE_KUBE_RBAC_PROXY to ODH variant

### DIFF
--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -22,7 +22,7 @@ spec:
         # kube-rbac-proxy sidecar image for authentication controller.
         # Value comes from params.env (odh-kube-rbac-proxy-image), overridden at deploy
         # time by the ODH/RHOAI operator via imageParamMap
-        # (RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE). Read at startup by init() in
+        # (RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE). Read at startup by init() in
         # authentication_controller.go.
-        - name: RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE
+        - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
           value: $(odh-kube-rbac-proxy-image)

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -56,7 +56,7 @@ const (
 // oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
 // init() from the operator's env vars so that disconnected installs can override
 // the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE or
-// RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via the openshift
+// RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via the openshift
 // overlay and substituted by the ODH/RHOAI operator from CSV relatedImages).
 var oidcProxyContainerImage = defaultOIDCProxyContainerImage
 
@@ -64,8 +64,8 @@ var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not fou
 
 func init() {
 	for _, envVar := range []string{
+		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
 		"RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE",
-		"RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
 	} {
 		if image := strings.TrimSpace(os.Getenv(envVar)); image != "" {
 			oidcProxyContainerImage = image

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -55,9 +55,9 @@ const (
 
 // oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
 // init() from the operator's env vars so that disconnected installs can override
-// the image via RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE or
-// RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via the openshift
-// overlay and substituted by the ODH/RHOAI operator from CSV relatedImages).
+// the image via RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via
+// the openshift overlay and substituted by the ODH/RHOAI operator from CSV
+// relatedImages).
 var oidcProxyContainerImage = defaultOIDCProxyContainerImage
 
 var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not found yet")
@@ -65,7 +65,6 @@ var errAutoscalerRoleBindingPending = errors.New("autoscaler RoleBinding not fou
 func init() {
 	for _, envVar := range []string{
 		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
-		"RELATED_IMAGE_ODH_KUBE_AUTH_PROXY_IMAGE",
 	} {
 		if image := strings.TrimSpace(os.Getenv(envVar)); image != "" {
 			oidcProxyContainerImage = image


### PR DESCRIPTION
Aligns with the naming convention used by all other operator components.

<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
Platform team said not to use the image tag I had in last PR so using this new one. I had tried this and CI failed in ODH, but apparently it was just a flake as it seems to be passing now, so just setting the name back now

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-69996

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OpenShift gateway environment configuration to use the correct kube-rbac-proxy image variable aligned with current ODH naming.
  * Adjusted image override resolution to prefer the updated kube-rbac-proxy setting first, while still falling back to the existing auth-proxy override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->