### PR TITLE
RHOAIENG-69996: backport kube-rbac-proxy image wiring and remove dead OAuth proxy code (3.3)

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/format-go.sh",
+        "matcher": "\\.go$"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/block-dangerous.sh",
+        "failClosed": true
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block-dangerous.sh
+++ b/.cursor/hooks/block-dangerous.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+command_str=$(echo "$input" | jq -r '.command // empty')
+
+if echo "$command_str" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f\b'; then
+  echo '{
+    "permission": "deny",
+    "user_message": "Force-push blocked by project hook. Use a normal push or override manually.",
+    "agent_message": "Hook denied force-push. Do not retry with --force."
+  }'
+  exit 0
+fi
+
+if echo "$command_str" | grep -qE '\brm\s+-[a-zA-Z]*r[a-zA-Z]*f\b|\brm\s+-[a-zA-Z]*f[a-zA-Z]*r\b'; then
+  echo '{
+    "permission": "deny",
+    "user_message": "rm -rf blocked by project hook. Remove files individually or override manually.",
+    "agent_message": "Hook denied rm -rf. Use targeted file removal instead."
+  }'
+  exit 0
+fi
+
+echo '{ "permission": "allow" }'
+exit 0

--- a/.cursor/hooks/format-go.sh
+++ b/.cursor/hooks/format-go.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+file=$(echo "$input" | jq -r '.path // empty')
+
+if [[ -z "$file" || ! -f "$file" || "$file" != *.go ]]; then
+  exit 0
+fi
+
+if command -v gofumpt &>/dev/null; then
+  gofumpt -w "$file"
+elif command -v gofmt &>/dev/null; then
+  gofmt -s -w "$file"
+fi
+
+exit 0

--- a/ray-operator/config/openshift/gateway-env-patch.yaml
+++ b/ray-operator/config/openshift/gateway-env-patch.yaml
@@ -19,3 +19,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # kube-rbac-proxy sidecar image for authentication controller.
+        # Value comes from params.env (odh-kube-rbac-proxy-image), overridden at deploy
+        # time by the ODH/RHOAI operator via imageParamMap
+        # (RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE). Read at startup by init() in
+        # authentication_controller.go.
+        - name: RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE
+          value: $(odh-kube-rbac-proxy-image)

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -26,6 +26,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.odh-kuberay-operator-controller-image
+- name: odh-kube-rbac-proxy-image
+  objref:
+    kind: ConfigMap
+    name: ray-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh-kube-rbac-proxy-image
 
 resources:
 - ray_operator_scc.yaml

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,2 +1,3 @@
 namespace=opendatahub
 odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.2
+odh-kube-rbac-proxy-image=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -2,14 +2,9 @@ package ray
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math/big"
-	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -44,19 +39,34 @@ const (
 	// Finalizer for ensuring cleanup of cross-namespace resources (HTTPRoutes)
 	authenticationFinalizer = "ray.io/authentication-resources"
 
-	// OAuth proxy constants
-	oauthProxyContainerName = "oauth-proxy"
-	oauthProxyVolumeName    = "proxy-tls-secret"
-	authProxyPort           = 8443
-	oauthProxyPortName      = "oauth-proxy"
+	authProxyPort = 8443
 
-	oauthConfigVolumeName = "oauth-config"
+	oidcProxyContainerName = "kube-rbac-proxy"
+	oidcProxyPortName      = "https"
 
-	oidcProxyContainerName  = "kube-rbac-proxy"
-	oidcProxyPortName       = "https"
-	oauthProxyImage         = "registry.redhat.io/openshift4/ose-oauth-proxy:latest"
-	oidcProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
+	// defaultOIDCProxyContainerImage is the fallback image used when no RELATED_IMAGE_*
+	// env var is set. Must match an entry in the RHOAI CSV relatedImages so it is
+	// mirrored correctly in disconnected environments.
+	defaultOIDCProxyContainerImage = "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:11828cdb31cd9c1e15bc9e31c7e4669daf71c84c028cad2df5dbab68150da273"
 )
+
+// oidcProxyContainerImage holds the resolved kube-rbac-proxy image. Populated by
+// init() from the operator's env vars so that disconnected installs can override
+// the image via RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE (injected on OpenShift via
+// the openshift overlay and substituted by the ODH/RHOAI operator from CSV
+// relatedImages).
+var oidcProxyContainerImage = defaultOIDCProxyContainerImage
+
+func init() {
+	for _, envVar := range []string{
+		"RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE",
+	} {
+		if image := strings.TrimSpace(os.Getenv(envVar)); image != "" {
+			oidcProxyContainerImage = image
+			return
+		}
+	}
+}
 
 // AuthenticationController is a completely independent controller that watches authentication-related
 // resources (ConfigMaps, ServiceAccounts, OpenShift Routes) and manages authentication configurations for Ray clusters on Openshift.
@@ -807,117 +817,6 @@ func (r *AuthenticationController) ensureOAuthServiceAccount(ctx context.Context
 	}
 
 	return nil
-}
-
-// NOTE: Pod recreation logic removed - Kubernetes pods are immutable
-// You cannot add containers to running pods, so we don't try to retrofit existing pods
-// OAuth sidecar is automatically injected by RayCluster controller during pod creation
-// Users must delete and recreate their RayCluster to enable OAuth on existing clusters
-
-// generateSelfSignedCert generates a self-signed certificate for OAuth proxy
-func generateSelfSignedCert(cluster *rayv1.RayCluster) ([]byte, []byte, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			Organization: []string{"KubeRay OAuth Proxy"},
-			CommonName:   cluster.Name + "-oauth-proxy",
-		},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1)},
-		DNSNames: []string{
-			"localhost",
-			cluster.Name,
-			fmt.Sprintf("%s.%s", cluster.Name, cluster.Namespace),
-			fmt.Sprintf("%s.%s.svc", cluster.Name, cluster.Namespace),
-			fmt.Sprintf("%s.%s.svc.cluster.local", cluster.Name, cluster.Namespace),
-		},
-	}
-
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
-
-	return certPEM, keyPEM, nil
-}
-
-// GetOAuthProxySidecar returns the OAuth proxy sidecar container configuration
-// This can be used by the RayCluster controller to inject the sidecar
-func GetOAuthProxySidecar(cluster *rayv1.RayCluster) corev1.Container {
-	namer := utils.NewResourceNamer(cluster)
-	return corev1.Container{
-		Name:            oauthProxyContainerName,
-		Image:           oauthProxyImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Ports: []corev1.ContainerPort{
-			utils.CreateContainerPort(authProxyPort, oauthProxyPortName),
-		},
-		Args: []string{
-			fmt.Sprintf("--https-address=:%d", authProxyPort),
-			"--provider=openshift",
-			fmt.Sprintf("--openshift-service-account=%s", namer.ServiceAccountName(utils.ModeIntegratedOAuth)),
-			"--upstream=http://localhost:8265",
-			"--tls-cert=/etc/tls/private/tls.crt",
-			"--tls-key=/etc/tls/private/tls.key",
-			"--cookie-secret=$(COOKIE_SECRET)",
-			fmt.Sprintf("--openshift-delegate-urls=%s", utils.FormatOAuthDelegateURLs(cluster.Namespace)),
-			"--skip-provider-button",
-		},
-		Env: []corev1.EnvVar{
-			utils.CreateEnvVarFromSecret("COOKIE_SECRET", namer.SecretName(utils.ModeIntegratedOAuth), "cookie_secret"),
-		},
-		VolumeMounts: []corev1.VolumeMount{
-			utils.CreateVolumeMount(oauthProxyVolumeName, "/etc/tls/private", true),
-		},
-		// Add resource limits to prevent excessive resource usage
-		Resources: utils.StandardProxyResources(),
-		// Add liveness probe to detect if OAuth proxy is healthy
-		LivenessProbe: utils.CreateProbe(utils.ProbeConfig{
-			Path:                "/oauth/healthz",
-			Port:                authProxyPort,
-			Scheme:              corev1.URISchemeHTTPS,
-			InitialDelaySeconds: 30,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       10,
-			SuccessThreshold:    1,
-			FailureThreshold:    3,
-		}),
-		// Add readiness probe to prevent routing traffic before OAuth proxy is ready
-		ReadinessProbe: utils.CreateProbe(utils.ProbeConfig{
-			Path:                "/oauth/healthz",
-			Port:                authProxyPort,
-			Scheme:              corev1.URISchemeHTTPS,
-			InitialDelaySeconds: 5,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       5,
-			SuccessThreshold:    1,
-			FailureThreshold:    3,
-		}),
-	}
-}
-
-// GetOAuthProxyVolumes returns the volumes needed for OAuth proxy sidecar
-func GetOAuthProxyVolumes(cluster *rayv1.RayCluster) []corev1.Volume {
-	namer := utils.NewResourceNamer(cluster)
-	return []corev1.Volume{
-		utils.CreateSecretVolume(oauthConfigVolumeName, namer.SecretName(utils.ModeIntegratedOAuth)),
-		utils.CreateSecretVolume(oauthProxyVolumeName, namer.TLSSecretName(utils.ModeIntegratedOAuth)),
-	}
 }
 
 func GetOIDCProxySidecar(cluster *rayv1.RayCluster) corev1.Container {

--- a/ray-operator/controllers/ray/authentication_controller_unit_test.go
+++ b/ray-operator/controllers/ray/authentication_controller_unit_test.go
@@ -691,58 +691,6 @@ func TestMapAuthResourceToRayClusters(t *testing.T) {
 	}
 }
 
-func TestGetOAuthProxySidecar(t *testing.T) {
-	cluster := &rayv1.RayCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster",
-			Namespace: "default",
-		},
-	}
-
-	container := GetOAuthProxySidecar(cluster)
-
-	assert.Equal(t, oauthProxyContainerName, container.Name)
-	assert.Equal(t, oauthProxyImage, container.Image)
-	assert.NotEmpty(t, container.Args)
-	assert.NotEmpty(t, container.Env)
-	assert.NotEmpty(t, container.VolumeMounts)
-	assert.NotEmpty(t, container.Ports)
-
-	// Verify port configuration
-	assert.Equal(t, int32(authProxyPort), container.Ports[0].ContainerPort)
-	assert.Equal(t, oauthProxyPortName, container.Ports[0].Name)
-
-	// Verify resource limits are set
-	assert.NotNil(t, container.Resources.Requests)
-	assert.NotNil(t, container.Resources.Limits)
-
-	// Verify probes are configured
-	assert.NotNil(t, container.LivenessProbe)
-	assert.NotNil(t, container.ReadinessProbe)
-}
-
-func TestGetOAuthProxyVolumes(t *testing.T) {
-	cluster := &rayv1.RayCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster",
-			Namespace: "default",
-		},
-	}
-
-	volumes := GetOAuthProxyVolumes(cluster)
-
-	assert.Len(t, volumes, 2)
-
-	// Verify volume names
-	volumeNames := make(map[string]bool)
-	for _, vol := range volumes {
-		volumeNames[vol.Name] = true
-	}
-
-	assert.True(t, volumeNames[oauthConfigVolumeName])
-	assert.True(t, volumeNames[oauthProxyVolumeName])
-}
-
 func TestGetOIDCProxySidecar(t *testing.T) {
 	cluster := &rayv1.RayCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -808,27 +756,6 @@ func TestHelperFunctions(t *testing.T) {
 		name := namer.TLSSecretName(utils.ModeIntegratedOAuth)
 		assert.Equal(t, "test-cluster-oauth-tls", name)
 	})
-}
-
-func TestGenerateSelfSignedCert(t *testing.T) {
-	cluster := &rayv1.RayCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster",
-			Namespace: "default",
-		},
-	}
-
-	cert, key, err := generateSelfSignedCert(cluster)
-
-	require.NoError(t, err)
-	assert.NotEmpty(t, cert)
-	assert.NotEmpty(t, key)
-
-	// Verify cert and key are valid PEM -  Handled this way due to pre-commit hook false positive
-	assert.Contains(t, string(cert), "BEGIN CERTIFICATE")
-	assert.Contains(t, string(cert), "END CERTIFICATE")
-	assert.Contains(t, string(key), "BEGIN "+"PRIVATE KEY")
-	assert.Contains(t, string(key), "END "+"PRIVATE KEY")
 }
 
 func TestReconcile_RayClusterNotFound(t *testing.T) {

--- a/ray-operator/controllers/ray/utils/auth_sidecar.go
+++ b/ray-operator/controllers/ray/utils/auth_sidecar.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -224,9 +222,4 @@ func CreateEnvVarFromSecret(envName, secretName, secretKey string) corev1.EnvVar
 			},
 		},
 	}
-}
-
-// FormatOAuthDelegateURLs formats the OpenShift OAuth delegate URLs
-func FormatOAuthDelegateURLs(namespace string) string {
-	return fmt.Sprintf(`{"/":{"resource":"pods","namespace":"%s","verb":"get"}}`, namespace)
 }

--- a/ray-operator/controllers/ray/utils/auth_sidecar_test.go
+++ b/ray-operator/controllers/ray/utils/auth_sidecar_test.go
@@ -267,10 +267,3 @@ func TestCreateEnvVarFromSecret(t *testing.T) {
 	assert.Equal(t, "secret-name", envVar.ValueFrom.SecretKeyRef.Name)
 	assert.Equal(t, "secret-key", envVar.ValueFrom.SecretKeyRef.Key)
 }
-
-func TestFormatOAuthDelegateURLs(t *testing.T) {
-	result := FormatOAuthDelegateURLs("test-namespace")
-
-	expected := `{"/":{"resource":"pods","namespace":"test-namespace","verb":"get"}}`
-	assert.Equal(t, expected, result)
-}


### PR DESCRIPTION
## Summary

Backport of disconnected readiness fixes from `dev` to the `3.3` release branch:

- Wire `RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE` so disconnected installs can override the kube-rbac-proxy sidecar image via the ODH/RHOAI operator's `imageParamMap`. Adds `init()` env var lookup, kustomize vars, `params.env` entry, and `gateway-env-patch.yaml` wiring.
- Remove dead OAuth proxy code (`GetOAuthProxySidecar`, `GetOAuthProxyVolumes`, `generateSelfSignedCert`, `FormatOAuthDelegateURLs`) and associated constants/tests. Both `ModeIntegratedOAuth` and `ModeOIDC` exclusively use the kube-rbac-proxy sidecar; the legacy `ose-oauth-proxy` path was never called from production code and used an unresolvable `:latest` image tag.

Combines the equivalent of PRs #202, #203, and #211 from `dev` into a single backport commit.

Companion operator PR needed on `odh-3.3.0` to add the `imageParamMap` entry.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./controllers/ray/...` passes
- [ ] Unit tests pass (`go test ./controllers/ray/...`)
- [ ] CI passes