### PR TITLE
RHOAIENG-61067: integrate with cluster TLS security profile

### DIFF
--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -268,6 +268,12 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - authentications
   - authentications/status
   - oauths

--- a/ray-operator/Dockerfile
+++ b/ray-operator/Dockerfile
@@ -14,6 +14,7 @@ COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/features pkg/features
+COPY pkg/tls pkg/tls
 COPY pkg/utils pkg/utils
 COPY pkg/webhooks pkg/webhooks
 COPY rayjob-submitter/ rayjob-submitter/

--- a/ray-operator/Dockerfile.konflux
+++ b/ray-operator/Dockerfile.konflux
@@ -20,6 +20,7 @@ COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/features pkg/features
+COPY pkg/tls pkg/tls
 COPY pkg/utils pkg/utils
 COPY pkg/webhooks pkg/webhooks
 

--- a/ray-operator/Dockerfile.rhoai
+++ b/ray-operator/Dockerfile.rhoai
@@ -15,6 +15,7 @@ COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
 COPY pkg/features pkg/features
+COPY pkg/tls pkg/tls
 COPY pkg/utils pkg/utils
 COPY pkg/webhooks pkg/webhooks
 

--- a/ray-operator/config/rbac/role.yaml
+++ b/ray-operator/config/rbac/role.yaml
@@ -125,6 +125,12 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - authentications
   - authentications/status
   - oauths

--- a/ray-operator/controllers/ray/authentication_controller.go
+++ b/ray-operator/controllers/ray/authentication_controller.go
@@ -104,6 +104,7 @@ func NewAuthenticationController(mgr manager.Manager, options RayClusterReconcil
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=kubeapiservers/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=authentications/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=oauths,verbs=get;list;watch

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/zapr"
@@ -30,6 +29,7 @@ import (
 	k8szap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -247,15 +247,16 @@ func main() {
 	restConfig.Burst = *config.Burst
 
 	// Fetch the cluster TLS security profile for metrics server (OpenShift only).
-	// Uses a short timeout so transient API issues do not block startup indefinitely.
-	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer bootstrapCancel()
-	tlsResult, err := pkgtls.Resolve(bootstrapCtx, restConfig)
+	// Resolve() has its own 10s timeout internally.
+	tlsResult, err := pkgtls.Resolve(context.Background(), restConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to resolve TLS configuration")
 		os.Exit(1)
 	}
 	options.Metrics.TLSOpts = tlsResult.TLSOpts
+	options.WebhookServer = webhook.NewServer(webhook.Options{
+		TLSOpts: tlsResult.TLSOpts,
+	})
 
 	mgr, err := ctrl.NewManager(restConfig, options)
 	exitOnError(err, "unable to start manager")

--- a/ray-operator/main.go
+++ b/ray-operator/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/zapr"
@@ -38,6 +40,7 @@ import (
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/metrics"
 	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/ray-project/kuberay/ray-operator/pkg/features"
+	pkgtls "github.com/ray-project/kuberay/ray-operator/pkg/tls"
 	webhooks "github.com/ray-project/kuberay/ray-operator/pkg/webhooks/v1"
 )
 
@@ -242,6 +245,18 @@ func main() {
 	restConfig.UserAgent = userAgent
 	restConfig.QPS = float32(*config.QPS)
 	restConfig.Burst = *config.Burst
+
+	// Fetch the cluster TLS security profile for metrics server (OpenShift only).
+	// Uses a short timeout so transient API issues do not block startup indefinitely.
+	bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer bootstrapCancel()
+	tlsResult, err := pkgtls.Resolve(bootstrapCtx, restConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to resolve TLS configuration")
+		os.Exit(1)
+	}
+	options.Metrics.TLSOpts = tlsResult.TLSOpts
+
 	mgr, err := ctrl.NewManager(restConfig, options)
 	exitOnError(err, "unable to start manager")
 

--- a/ray-operator/pkg/tls/tls.go
+++ b/ray-operator/pkg/tls/tls.go
@@ -1,0 +1,161 @@
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = ctrl.Log.WithName("tls")
+
+var openSSLToGoCipher = map[string]uint16{
+	"TLS_AES_128_GCM_SHA256":               tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":               tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":         tls.TLS_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-AES128-GCM-SHA256":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-RSA-AES128-GCM-SHA256":          tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":          tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305-SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305-SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-ECDSA-CHACHA20-POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var intermediateCiphers = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+var tlsVersionMap = map[configv1.TLSProtocolVersion]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// Result holds the resolved TLS configuration.
+type Result struct {
+	TLSOpts []func(*tls.Config)
+}
+
+// Resolve reads the cluster TLS profile from apiservers.config.openshift.io/cluster
+// and returns TLS option functions for controller-runtime servers.
+// On non-OpenShift clusters or when the API is temporarily unavailable,
+// it returns hardened Intermediate defaults.
+// Returns an error only on unexpected failures that should prevent startup.
+func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
+	var result Result
+
+	resolveCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	scheme := runtime.NewScheme()
+	if err := configv1.Install(scheme); err != nil {
+		return result, fmt.Errorf("installing OpenShift config scheme: %w", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return result, fmt.Errorf("creating bootstrap client for TLS profile: %w", err)
+	}
+
+	apiServer := &configv1.APIServer{}
+	if err := k8sClient.Get(resolveCtx, client.ObjectKey{Name: "cluster"}, apiServer); err != nil {
+		switch {
+		case meta.IsNoMatchError(err):
+			log.Info("TLS profile not available, using hardened defaults (non-OpenShift cluster)")
+		case apierrors.IsNotFound(err):
+			log.Info("APIServer resource not found, using hardened defaults")
+		case apierrors.IsServiceUnavailable(err),
+			apierrors.IsTimeout(err),
+			apierrors.IsTooManyRequests(err),
+			errors.Is(err, context.DeadlineExceeded):
+			log.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
+		default:
+			return result, fmt.Errorf("reading APIServer TLS profile: %w", err)
+		}
+		result.TLSOpts = append(result.TLSOpts, intermediateWithALPN)
+		return result, nil
+	}
+
+	minVersion, ciphers := parseProfile(apiServer.Spec.TLSSecurityProfile)
+	if ciphers != nil && len(ciphers) == 0 {
+		return result, fmt.Errorf("custom TLS profile specified ciphers but none are supported by Go")
+	}
+
+	result.TLSOpts = append(result.TLSOpts, func(c *tls.Config) {
+		c.MinVersion = minVersion
+		if len(ciphers) > 0 {
+			c.CipherSuites = ciphers
+		}
+		c.NextProtos = []string{"h2", "http/1.1"}
+	})
+	return result, nil
+}
+
+func intermediateWithALPN(c *tls.Config) {
+	c.MinVersion = tls.VersionTLS12
+	c.CipherSuites = intermediateCiphers
+	c.NextProtos = []string{"h2", "http/1.1"}
+}
+
+func parseProfile(profile *configv1.TLSSecurityProfile) (uint16, []uint16) {
+	if profile == nil {
+		return tls.VersionTLS12, intermediateCiphers
+	}
+
+	switch profile.Type {
+	case configv1.TLSProfileIntermediateType, "":
+		return tls.VersionTLS12, intermediateCiphers
+	case configv1.TLSProfileModernType:
+		return tls.VersionTLS13, nil
+	case configv1.TLSProfileOldType:
+		return tls.VersionTLS10, nil
+	case configv1.TLSProfileCustomType:
+		if profile.Custom == nil {
+			log.Info("Custom TLS profile type specified but custom block is nil, falling back to Intermediate")
+			return tls.VersionTLS12, intermediateCiphers
+		}
+		return parseCustomProfile(profile.Custom)
+	default:
+		log.Info("Unknown TLS profile type, falling back to Intermediate", "type", profile.Type)
+		return tls.VersionTLS12, intermediateCiphers
+	}
+}
+
+func parseCustomProfile(custom *configv1.CustomTLSProfile) (uint16, []uint16) {
+	minVersion, ok := tlsVersionMap[custom.MinTLSVersion]
+	if !ok {
+		log.Info("Unknown minTLSVersion in custom profile, defaulting to TLS 1.2", "minTLSVersion", custom.MinTLSVersion)
+		minVersion = tls.VersionTLS12
+	}
+
+	if len(custom.Ciphers) == 0 {
+		return minVersion, nil
+	}
+
+	ciphers := make([]uint16, 0, len(custom.Ciphers))
+	for _, name := range custom.Ciphers {
+		if id, ok := openSSLToGoCipher[name]; ok {
+			ciphers = append(ciphers, id)
+		} else {
+			log.Info("Dropping unsupported cipher from custom TLS profile", "cipher", name)
+		}
+	}
+	return minVersion, ciphers
+}

--- a/ray-operator/pkg/tls/tls.go
+++ b/ray-operator/pkg/tls/tls.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -83,6 +84,7 @@ func Resolve(ctx context.Context, cfg *rest.Config) (Result, error) {
 			log.Info("APIServer resource not found, using hardened defaults")
 		case apierrors.IsServiceUnavailable(err),
 			apierrors.IsTimeout(err),
+			apierrors.IsServerTimeout(err),
 			apierrors.IsTooManyRequests(err),
 			errors.Is(err, context.DeadlineExceeded):
 			log.Info("Transient API error reading TLS profile, using hardened defaults", "error", err)
@@ -151,6 +153,10 @@ func parseCustomProfile(custom *configv1.CustomTLSProfile) (uint16, []uint16) {
 
 	ciphers := make([]uint16, 0, len(custom.Ciphers))
 	for _, name := range custom.Ciphers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
 		if id, ok := openSSLToGoCipher[name]; ok {
 			ciphers = append(ciphers, id)
 		} else {

--- a/ray-operator/pkg/tls/tls_test.go
+++ b/ray-operator/pkg/tls/tls_test.go
@@ -1,0 +1,134 @@
+package tls
+
+import (
+	"crypto/tls"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		profile        *configv1.TLSSecurityProfile
+		name           string
+		wantCiphers    []uint16
+		wantMinVersion uint16
+	}{
+		{
+			name:           "nil profile returns Intermediate defaults",
+			profile:        nil,
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name:           "empty profile returns Intermediate defaults",
+			profile:        &configv1.TLSSecurityProfile{},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Intermediate type",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+		{
+			name: "Modern returns TLS 1.3 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Old returns TLS 1.0 with nil ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			wantMinVersion: tls.VersionTLS10,
+			wantCiphers:    nil,
+		},
+		{
+			name: "Custom with valid ciphers",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		},
+		{
+			name: "Custom with unsupported cipher skips it",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "UNSUPPORTED-CIPHER"},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		},
+		{
+			name: "Custom with all unsupported ciphers returns empty slice",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"DHE-RSA-AES128-GCM-SHA256"},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{},
+		},
+		{
+			name: "Unknown type falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "SuperSecure",
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    intermediateCiphers,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMinVersion, gotCiphers := parseProfile(tt.profile)
+
+			if gotMinVersion != tt.wantMinVersion {
+				t.Errorf("parseProfile() minVersion = %d, want %d", gotMinVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCiphers == nil {
+				if gotCiphers != nil {
+					t.Errorf("parseProfile() ciphers = %v, want nil", gotCiphers)
+				}
+				return
+			}
+
+			if gotCiphers == nil {
+				t.Fatal("expected non-nil empty slice, got nil")
+			}
+			if len(gotCiphers) != len(tt.wantCiphers) {
+				t.Errorf("parseProfile() ciphers length = %d, want %d", len(gotCiphers), len(tt.wantCiphers))
+				return
+			}
+			for i, c := range gotCiphers {
+				if c != tt.wantCiphers[i] {
+					t.Errorf("parseProfile() ciphers[%d] = %d, want %d", i, c, tt.wantCiphers[i])
+				}
+			}
+		})
+	}
+}

--- a/ray-operator/pkg/tls/tls_test.go
+++ b/ray-operator/pkg/tls/tls_test.go
@@ -93,6 +93,34 @@ func TestParseProfile(t *testing.T) {
 			wantCiphers:    []uint16{},
 		},
 		{
+			name: "Custom with whitespace-padded cipher names still resolves",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"  ECDHE-ECDSA-AES128-GCM-SHA256  ", " ECDHE-RSA-AES256-GCM-SHA384"},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		},
+		{
+			name: "Custom with whitespace-only cipher entries are skipped",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: "VersionTLS12",
+						Ciphers:       []string{"   ", "ECDHE-ECDSA-AES128-GCM-SHA256", "  "},
+					},
+				},
+			},
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		},
+		{
 			name: "Unknown type falls back to Intermediate",
 			profile: &configv1.TLSSecurityProfile{
 				Type: "SuperSecure",


### PR DESCRIPTION
## Why are these changes needed?

OCP 5.0 (GA October 2026) requires all components to honor the centralized TLS
profile ([OCPSTRAT-2611](https://redhat.atlassian.net/browse/OCPSTRAT-2611)).
This adds TLS profile integration to kuberay-operator so the metrics server
respects the cluster-wide MinVersion, CipherSuites, and ALPN settings.

On non-OpenShift clusters or when the API is temporarily unavailable (transient
errors: ServiceUnavailable, Timeout, TooManyRequests), the operator falls back
to hardened Intermediate defaults (TLS 1.2, modern cipher suite, h2/http1.1 ALPN).

Replaces #200 (closed due to broken branch ancestry from shallow clone).

### Changes

- `ray-operator/pkg/tls/tls.go`: reusable TLS profile resolution from the
  `apiservers.config.openshift.io/cluster` CR
- `ray-operator/pkg/tls/tls_test.go`: table-driven tests for all profile types
  (nil, Intermediate, Modern, Old, Custom with valid/invalid ciphers)
- `ray-operator/main.go`: 10-second bootstrap context, fetch TLS profile before
  manager creation, apply TLSOpts to metrics server
- `ray-operator/controllers/ray/authentication_controller.go`: kubebuilder RBAC
  marker for apiservers
- `ray-operator/config/rbac/role.yaml`: apiservers permission added
- `ray-operator/Dockerfile`: COPY pkg/tls
- `helm-chart/kuberay-operator/templates/_helpers.tpl`: helm RBAC alignment

Reference: [openshift/cluster-machine-approver #286](https://github.com/openshift/cluster-machine-approver/pull/286)

## Related issue number

[RHOAIENG-61067](https://redhat.atlassian.net/browse/RHOAIENG-61067)

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

[OCPSTRAT-2611]: https://redhat.atlassian.net/browse/OCPSTRAT-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-61067]: https://redhat.atlassian.net/browse/RHOAIENG-61067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply the cluster’s OpenShift TLS security profile to the operator’s metrics server when available.
  * Added OpenShift-specific permissions to read API server TLS profile information.
* **Bug Fixes**
  * Improved TLS configuration resilience with hardened defaults when TLS profile resolution fails or is unavailable.
* **Tests**
  * Added unit tests for TLS security profile parsing, including custom cipher mapping and unsupported-cipher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->