### PR TITLE
RHOAIENG-61477: Tier 3 updates for Ray repos

### DIFF
--- a/.claude/rules/apiserver.md
+++ b/.claude/rules/apiserver.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - apiserver/**
+---
+
+# apiserver
+
+Optional REST/gRPC API server for managing Ray resources. Alpha quality.
+**APIServer V1 is deprecated** — V2 lives in `apiserversdk/` (see `apiserversdk/docs/migration.md`).
+
+## Architecture
+
+```text
+cmd/main.go        — boots gRPC + HTTP gateway, wires all components
+pkg/server/        — gRPC service implementations (one per resource kind)
+pkg/manager/       — business logic layer, CRUD orchestration against Ray CRDs
+pkg/client/        — Kubernetes client wrappers (one per resource kind)
+pkg/model/         — proto <-> K8s CRD data conversion
+pkg/util/          — helpers, defaults, error types
+pkg/interceptor/   — gRPC interceptors (logging, etc.)
+```
+
+## Generated Files — Do Not Edit
+
+- `pkg/swagger/datafile.go` — Swagger UI assets via go-bindata, regenerate with `make build-swagger`
+- `*_mock.go` — MockGen mocks (`pkg/client/`, `pkg/manager/`)
+
+## Dependencies
+
+- Protobuf API definitions: `proto/go_client/` (generated from `proto/*.proto`)
+- Ray CRD types: `ray-operator/apis/ray/v1`
+- Ray typed client: `ray-operator/pkg/client/`
+
+## Commands
+
+- `make test` — unit tests
+- `make e2e-test` — end-to-end tests
+- `make build-swagger` — regenerate Swagger UI assets
+- `make start-local-apiserver` — full local stack (kind + operator + apiserver)

--- a/.claude/rules/helm-chart.md
+++ b/.claude/rules/helm-chart.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - helm-chart/**
+---
+
+# helm-chart
+
+Helm charts for deploying KubeRay components. Three charts, all versioned together.
+
+## Charts
+
+| Chart | Purpose |
+|---|---|
+| `kuberay-operator/` | Operator deployment + CRDs |
+| `kuberay-apiserver/` | APIServer deployment (optional security proxy sidecar) |
+| `ray-cluster/` | Sample RayCluster CR |
+
+## Do Not Edit Directly
+
+- **CRDs** (`kuberay-operator/crds/*.yaml`): synced from
+  `ray-operator/config/crd/bases/` via `make helm` in `ray-operator/`.
+  Edit the Go types in `ray-operator/apis/ray/v1/*_types.go` and
+  regenerate instead.
+- **README.md** files: generated from `README.md.gotmpl` by helm-docs. Edit the `.gotmpl` source file, not the rendered README.
+
+## Testing and Validation
+
+- `make helm-lint` — lint all charts
+- `make helm-unittest` — run helm-unittest tests (in each chart's `tests/` dir)
+- `make helm-docs` — regenerate READMEs from `.gotmpl` templates
+- Pre-commit runs `kubeconform` to validate charts against CRD JSON schemas
+
+## Values Conventions
+
+- Chart values follow the upstream kuberay-operator defaults
+- Security-related values (auth proxy, CORS) are in the `security` block of `kuberay-apiserver`
+- Multi-namespace support is configured via `watchNamespace` in `kuberay-operator`

--- a/.claude/rules/ray-operator.md
+++ b/.claude/rules/ray-operator.md
@@ -1,0 +1,57 @@
+---
+paths:
+  - ray-operator/**
+---
+
+# ray-operator
+
+Core Kubernetes operator managing RayCluster, RayJob, RayService, and RayCronJob custom resources.
+Built with Kubebuilder v3 and controller-runtime.
+
+## Key Abstractions
+
+- **Reconcilers** (`controllers/ray/*_controller.go`): one per CR kind, implement the controller-runtime `Reconcile` loop
+- **Common builders** (`controllers/ray/common/`): construct K8s objects
+  (Pods, Services, Jobs, RBAC) from CR specs — shared across controllers
+- **Batch scheduler interface** (`controllers/ray/batchscheduler/interface/`):
+  pluggable gang schedulers (Volcano, YuniKorn, Kai, scheduler-plugins)
+- **Webhooks** (`pkg/webhooks/v1/`): admission validation and defaulting, registered when `ENABLE_WEBHOOKS=true`
+- **Feature gates** (`pkg/features/`): runtime toggles for experimental features (RayCronJob, RayJobDeletionPolicy, etc.)
+
+## Source of Truth for CRDs
+
+The Go type definitions in `apis/ray/v1/*_types.go` are the single source of truth.
+Everything else is derived:
+
+- CRD YAML: `make manifests` -> `config/crd/bases/`
+- Client code: `make generate` -> `pkg/client/`
+- Helm CRDs: `make helm` -> `helm-chart/kuberay-operator/crds/`
+- API docs: `make api-docs` -> `docs/reference/api.md`
+
+After changing `*_types.go`, run `make sync` to regenerate all derived artifacts.
+
+## Generated Files — Do Not Edit
+
+Files with `DO NOT EDIT` headers are auto-generated. Key patterns:
+
+- `apis/**/zz_generated.deepcopy.go` (controller-gen)
+- `pkg/client/**` (k8s code-generator: clientset, informers, listers, applyconfiguration)
+- `config/crd/bases/*.yaml` (controller-gen)
+- `*_mock.go` (MockGen)
+
+## Import Boundaries
+
+- `apis/` must NOT import from `controllers/` or `pkg/webhooks/` — types stay dependency-free
+  (CI-enforced via `depguard` in `.golangci.yml`)
+- `pkg/webhooks/` must NOT import from `controllers/` — webhooks depend only on API types and utilities
+  (prose-only; not CI-enforced until `controllers/ray/utils` is relocated)
+- `controllers/ray/common/` must NOT import specific `*_controller.go` files — shared builders are not coupled to one controller
+  (prose-only)
+
+## Commands
+
+- `make test` — unit tests
+- `make test-e2e` — end-to-end tests (requires kind cluster)
+- `make manifests` — regenerate CRDs, RBAC, webhook YAML
+- `make generate` — regenerate deepcopy and client code
+- `make sync` — manifests + generate + helm + api-docs

--- a/.cursor/rules/apiserver.mdc
+++ b/.cursor/rules/apiserver.mdc
@@ -1,0 +1,39 @@
+---
+description: Conventions and guardrails for the apiserver module
+globs: apiserver/**
+---
+
+# apiserver
+
+Optional REST/gRPC API server for managing Ray resources. Alpha quality.
+**APIServer V1 is deprecated** — V2 lives in `apiserversdk/` (see `apiserversdk/docs/migration.md`).
+
+## Architecture
+
+```text
+cmd/main.go        — boots gRPC + HTTP gateway, wires all components
+pkg/server/        — gRPC service implementations (one per resource kind)
+pkg/manager/       — business logic layer, CRUD orchestration against Ray CRDs
+pkg/client/        — Kubernetes client wrappers (one per resource kind)
+pkg/model/         — proto <-> K8s CRD data conversion
+pkg/util/          — helpers, defaults, error types
+pkg/interceptor/   — gRPC interceptors (logging, etc.)
+```
+
+## Generated Files — Do Not Edit
+
+- `pkg/swagger/datafile.go` — Swagger UI assets via go-bindata, regenerate with `make build-swagger`
+- `*_mock.go` — MockGen mocks (`pkg/client/`, `pkg/manager/`)
+
+## Dependencies
+
+- Protobuf API definitions: `proto/go_client/` (generated from `proto/*.proto`)
+- Ray CRD types: `ray-operator/apis/ray/v1`
+- Ray typed client: `ray-operator/pkg/client/`
+
+## Commands
+
+- `make test` — unit tests
+- `make e2e-test` — end-to-end tests
+- `make build-swagger` — regenerate Swagger UI assets
+- `make start-local-apiserver` — full local stack (kind + operator + apiserver)

--- a/.cursor/rules/helm-chart.mdc
+++ b/.cursor/rules/helm-chart.mdc
@@ -1,0 +1,37 @@
+---
+description: Conventions and guardrails for Helm charts
+globs: helm-chart/**
+---
+
+# helm-chart
+
+Helm charts for deploying KubeRay components. Three charts, all versioned together.
+
+## Charts
+
+| Chart | Purpose |
+|---|---|
+| `kuberay-operator/` | Operator deployment + CRDs |
+| `kuberay-apiserver/` | APIServer deployment (optional security proxy sidecar) |
+| `ray-cluster/` | Sample RayCluster CR |
+
+## Do Not Edit Directly
+
+- **CRDs** (`kuberay-operator/crds/*.yaml`): synced from
+  `ray-operator/config/crd/bases/` via `make helm` in `ray-operator/`.
+  Edit the Go types in `ray-operator/apis/ray/v1/*_types.go` and
+  regenerate instead.
+- **README.md** files: generated from `README.md.gotmpl` by helm-docs. Edit the `.gotmpl` source file, not the rendered README.
+
+## Testing and Validation
+
+- `make helm-lint` — lint all charts
+- `make helm-unittest` — run helm-unittest tests (in each chart's `tests/` dir)
+- `make helm-docs` — regenerate READMEs from `.gotmpl` templates
+- Pre-commit runs `kubeconform` to validate charts against CRD JSON schemas
+
+## Values Conventions
+
+- Chart values follow the upstream kuberay-operator defaults
+- Security-related values (auth proxy, CORS) are in the `security` block of `kuberay-apiserver`
+- Multi-namespace support is configured via `watchNamespace` in `kuberay-operator`

--- a/.cursor/rules/ray-operator.mdc
+++ b/.cursor/rules/ray-operator.mdc
@@ -1,0 +1,57 @@
+---
+description: Conventions and guardrails for the ray-operator module
+globs: ray-operator/**
+---
+
+# ray-operator
+
+Core Kubernetes operator managing RayCluster, RayJob, RayService, and RayCronJob custom resources.
+Built with Kubebuilder v3 and controller-runtime.
+
+## Key Abstractions
+
+- **Reconcilers** (`controllers/ray/*_controller.go`): one per CR kind, implement the controller-runtime `Reconcile` loop
+- **Common builders** (`controllers/ray/common/`): construct K8s objects
+  (Pods, Services, Jobs, RBAC) from CR specs — shared across controllers
+- **Batch scheduler interface** (`controllers/ray/batchscheduler/interface/`):
+  pluggable gang schedulers (Volcano, YuniKorn, Kai, scheduler-plugins)
+- **Webhooks** (`pkg/webhooks/v1/`): admission validation and defaulting, registered when `ENABLE_WEBHOOKS=true`
+- **Feature gates** (`pkg/features/`): runtime toggles for experimental features (RayCronJob, RayJobDeletionPolicy, etc.)
+
+## Source of Truth for CRDs
+
+The Go type definitions in `apis/ray/v1/*_types.go` are the single source of truth.
+Everything else is derived:
+
+- CRD YAML: `make manifests` -> `config/crd/bases/`
+- Client code: `make generate` -> `pkg/client/`
+- Helm CRDs: `make helm` -> `helm-chart/kuberay-operator/crds/`
+- API docs: `make api-docs` -> `docs/reference/api.md`
+
+After changing `*_types.go`, run `make sync` to regenerate all derived artifacts.
+
+## Generated Files — Do Not Edit
+
+Files with `DO NOT EDIT` headers are auto-generated. Key patterns:
+
+- `apis/**/zz_generated.deepcopy.go` (controller-gen)
+- `pkg/client/**` (k8s code-generator: clientset, informers, listers, applyconfiguration)
+- `config/crd/bases/*.yaml` (controller-gen)
+- `*_mock.go` (MockGen)
+
+## Import Boundaries
+
+- `apis/` must NOT import from `controllers/` or `pkg/webhooks/` — types stay dependency-free
+  (CI-enforced via `depguard` in `.golangci.yml`)
+- `pkg/webhooks/` must NOT import from `controllers/` — webhooks depend only on API types and utilities
+  (prose-only; not CI-enforced until `controllers/ray/utils` is relocated)
+- `controllers/ray/common/` must NOT import specific `*_controller.go` files — shared builders are not coupled to one controller
+  (prose-only)
+
+## Commands
+
+- `make test` — unit tests
+- `make test-e2e` — end-to-end tests (requires kind cluster)
+- `make manifests` — regenerate CRDs, RBAC, webhook YAML
+- `make generate` — regenerate deepcopy and client code
+- `make sync` — manifests + generate + helm + api-docs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,3 +17,8 @@
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] This PR is not tested :(
+
+## Architecture
+
+- [ ] This PR does not change component boundaries or API contracts
+- [ ] OR: I have updated the relevant design doc / DEVELOPMENT.md

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - asciicheck
+    - depguard
     - errcheck
     - ginkgolinter
     - gosec
@@ -24,6 +25,17 @@ linters:
     - noctx
     - revive
   settings:
+    depguard:
+      rules:
+        crd-types-boundary:
+          list-mode: lax
+          files:
+            - "**/ray-operator/apis/ray/**"
+          deny:
+            - pkg: "github.com/ray-project/kuberay/ray-operator/controllers"
+              desc: "CRD types (apis/ray/) must not import controllers/ — types must remain dependency-free"
+            - pkg: "github.com/ray-project/kuberay/ray-operator/pkg/webhooks"
+              desc: "CRD types (apis/ray/) must not import pkg/webhooks/"
     staticcheck:
       checks: ["all", "-SA1019", "-ST1001", "-ST1003", "-ST1005", "-QF1008"]
     ginkgolinter:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Enforced via `.pre-commit-config.yaml`:
 - **Status updates**: Use status subresource, update status separately
 - **Finalizers**: Required for cleanup logic
 - **RBAC**: Defined in `config/rbac/`
-- **Webhooks**: Validation and defaulting in `ray-operator/controllers/ray/common/`
+- **Webhooks**: Validation and defaulting in `ray-operator/pkg/webhooks/v1/`
 
 ### Project Modules
 
@@ -196,8 +196,43 @@ and corresponding unit tests.
   specific defaults (e.g. enforce `EnableSecureTrustedNetwork`, disable `EnableIngress`).
   Unit tests are adjacent: `raycluster_mutating_webhook_unit_test.go`.
 - **Kustomize**: `ray-operator/config/openshift/kustomization.yaml` — composes `../default`,
-  adds `webhook.yaml`, and applies patches like `webhook-deployment-patch.yaml` and
+  adds `webhook.yaml`, and applies patches like   `webhook-deployment-patch.yaml` and
   `kuberay-operator-image-patch.yaml`.
+
+## Generated Files — Do Not Edit
+
+These files are auto-generated. Never edit them directly; modify the source and regenerate.
+
+| Pattern | Generator | Regenerate with |
+| --- | --- | --- |
+| `ray-operator/apis/**/zz_generated.deepcopy.go` | controller-gen | `make generate` |
+| `ray-operator/pkg/client/**` | k8s code-generator | `make generate` |
+| `ray-operator/config/crd/bases/*.yaml` | controller-gen | `make manifests` |
+| `helm-chart/kuberay-operator/crds/*.yaml` | copied from config/crd | `make helm` |
+| `proto/go_client/**` | protoc-gen-go | `make generate` (in proto/) |
+| `proto/swagger/*.json` | protoc-gen-swagger | `make generate` (in proto/) |
+| `docs/reference/api.md` | crd-ref-docs | `make api-docs` |
+| `apiserver/pkg/swagger/datafile.go` | go-bindata | `make build-swagger` |
+| `*_mock.go` | MockGen | `go generate` |
+
+### CRD Source of Truth
+
+The Go types in `ray-operator/apis/ray/v1/*_types.go` are the single source of truth for all CRDs.
+
+```text
+apis/ray/v1/*_types.go  --(make manifests)--> config/crd/bases/*.yaml
+                        --(make generate)---> pkg/client/**
+                        --(make helm)-------> helm-chart/kuberay-operator/crds/
+                        --(make api-docs)---> docs/reference/api.md
+```
+
+After changing `*_types.go`, run `make sync` to regenerate all derived artifacts.
+CI runs `.github/workflows/consistency-check.yaml` to verify generated files match their sources.
+
+## Context File Maintenance
+
+Context files (`.cursor/rules/`, `.claude/rules/`, `CLAUDE.md`) are living documents.
+See the "Maintaining AI Context" section in CONTRIBUTING.md for the update process.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,13 @@ Refer to the template for more information on what goes into a PR description.
 
 A contributor proposes a design with a PR on the repository to allow for revisions and discussions. If a design needs to be discussed before formulating a document for it, make use of Google doc and GitHub issue to involve the community on the discussion.
 
+If a PR changes component boundaries, API contracts, or CRD schemas, the corresponding design doc or `DEVELOPMENT.md` must be updated in the same PR (or a linked follow-up). Examples of changes that require doc updates:
+
+- Adding or removing a CRD field in `ray-operator/apis/ray/v1/*_types.go`
+- Changing how controllers interact with webhooks or batch schedulers
+- Modifying the batch scheduler plugin interface
+- Altering the relationship between `ray-operator/` and `apiserver/` modules
+
 ### GitHub Issues
 
 GitHub Issues are used to file bugs, work items, and feature requests with actionable items/issues (Please refer to the "Reporting Bugs/Feature Requests" section below for more information).
@@ -67,6 +74,25 @@ If you run into any merge issues, checkout this [git tutorial](https://docs.gith
 ### Release Acknowledgements
 
 Once your PR is merged, your contributions will be acknowledged in every release, see [Release Notes](https://github.com/ray-project/kuberay/releases) for more details.
+
+## Maintaining AI Context
+
+This repository includes context files that help AI coding agents work reliably in the codebase:
+`CLAUDE.md` (root conventions), `.cursor/rules/` and `.claude/rules/` (module-specific rules).
+
+### When to update context files
+
+- **Reviewer catches a pattern issue on an AI-generated PR:** add a rule to the relevant `.cursor/rules/` or `.claude/rules/` file, or `CLAUDE.md`, to prevent the same mistake
+- **New generated files or API surfaces added:** update the generated files registry in `CLAUDE.md`
+- **Module boundaries change:** update the corresponding `.cursor/rules/` and `.claude/rules/` files and `depguard` rules in `.golangci.yml`
+
+### Rule lifecycle
+
+- New rules should be specific and actionable (e.g., "never edit `zz_generated.deepcopy.go`")
+- Prefer lint rules over prose warnings — lint rules are deterministic and enforced in CI
+- When updating module rules, change both `.cursor/rules/` and `.claude/rules/` in the same PR (body content must stay in sync; only frontmatter differs)
+- Periodically audit context files: remove lines that no longer prevent real failures
+- Treat context files as a living list of codebase conventions, not permanent configuration
 
 ## Finding contributions to work on
 


### PR DESCRIPTION
RHOAIENG-61477: Tier 3 updates for Ray repos
## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-61477

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for the API server, Helm charts, and Ray operator architecture, workflows, generated artifacts, and development commands.
  - Clarified CRD sources of truth, regeneration processes, webhook responsibilities, and maintenance of project context documentation.
  - Updated contribution guidance for documenting architectural and API changes.

- **Chores**
  - Added architecture checks to the pull request template.
  - Enabled linting rules to enforce import boundaries for CRD definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->