### PR TITLE
RHOAIENG-77829: Release New Version of KubeRay 1.6.2 for ODH + restore test resources to match upstream + add CI to validate resources untouched

### DIFF
--- a/.github/workflows/check-test-resources.yaml
+++ b/.github/workflows/check-test-resources.yaml
@@ -1,0 +1,79 @@
+# Fail if CI resource scenarios are already committed into test sources.
+# update-resources must produce a non-empty diff; a clean tree means the
+# scenario targets were baked into git (sync risk) instead of applied at runtime.
+name: check-test-resources
+
+on:
+  push:
+    branches:
+      - dev
+      - release-*
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - '**'
+
+jobs:
+  update-resources-must-modify-sources:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false) }}
+    defaults:
+      run:
+        working-directory: scripts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: v1.25
+          cache-dependency-path: scripts/go.mod
+
+      - name: build-image scenario must modify sources
+        run: |
+          set -euo pipefail
+          SUPPORT_GO="${GITHUB_WORKSPACE}/ray-operator/test/support/support.go"
+          LIGHTWEIGHT_GO="${GITHUB_WORKSPACE}/ray-operator/test/e2erayjob/rayjob_lightweight_test.go"
+
+          go run ./update-resources.go -scenario build-image "${SUPPORT_GO}"
+          go run ./update-resources.go -scenario build-image "${LIGHTWEIGHT_GO}"
+
+          if git -C "${GITHUB_WORKSPACE}" diff --quiet -- \
+            ray-operator/test/support/support.go \
+            ray-operator/test/e2erayjob/rayjob_lightweight_test.go; then
+            echo "::error::update-resources -scenario build-image made no changes."
+            echo "Test sources already match the build-image scenario; revert committed resource bumps"
+            echo "and rely on CI to apply update-resources at runtime."
+            exit 1
+          fi
+
+          echo "OK: build-image scenario modified:"
+          git -C "${GITHUB_WORKSPACE}" --no-pager diff --stat -- \
+            ray-operator/test/support/support.go \
+            ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+          git -C "${GITHUB_WORKSPACE}" checkout -- \
+            ray-operator/test/support/support.go \
+            ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+
+      - name: pr scenario must modify sources
+        run: |
+          set -euo pipefail
+          SUPPORT_GO="${GITHUB_WORKSPACE}/ray-operator/test/support/support.go"
+
+          go run ./update-resources.go -scenario pr "${SUPPORT_GO}"
+
+          if git -C "${GITHUB_WORKSPACE}" diff --quiet -- \
+            ray-operator/test/support/support.go; then
+            echo "::error::update-resources -scenario pr made no changes."
+            echo "Test sources already match the pr scenario; revert committed resource bumps"
+            echo "and rely on CI to apply update-resources at runtime."
+            exit 1
+          fi
+
+          echo "OK: pr scenario modified:"
+          git -C "${GITHUB_WORKSPACE}" --no-pager diff --stat -- \
+            ray-operator/test/support/support.go
+          git -C "${GITHUB_WORKSPACE}" checkout -- \
+            ray-operator/test/support/support.go

--- a/.tekton/odh-kuberay-operator-controller-release-push.yaml
+++ b/.tekton/odh-kuberay-operator-controller-release-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kuberay-operator:v1.4.4
+    value: quay.io/opendatahub/kuberay-operator:v1.6.2
   - name: dockerfile
     value: Dockerfile.rhoai
   - name: path-context

--- a/ray-operator/config/openshift/params.env
+++ b/ray-operator/config/openshift/params.env
@@ -1,3 +1,3 @@
 namespace=opendatahub
-odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.4.4
+odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v1.6.2
 odh-kube-rbac-proxy-image=quay.io/opendatahub/odh-kube-rbac-proxy:odh-stable

--- a/ray-operator/test/e2eautoscaler/support.go
+++ b/ray-operator/test/e2eautoscaler/support.go
@@ -31,12 +31,12 @@ func headPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 				).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("6G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
-						corev1.ResourceMemory: resource.MustParse("10G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4G"),
 					}))))
 }
 
@@ -56,12 +56,12 @@ func headPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfigu
 				WithEnv(corev1ac.EnvVar().WithName(utils.RAY_ENABLE_AUTOSCALER_V2).WithValue("1")).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("6G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
-						corev1.ResourceMemory: resource.MustParse("10G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("4G"),
 					}))))
 }
 
@@ -73,12 +73,12 @@ func workerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigu
 				WithImage(GetRayImage()).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1000m"),
-						corev1.ResourceMemory: resource.MustParse("3G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1G"),
 					}))))
 }
 
@@ -91,12 +91,12 @@ func workerPodTemplateApplyConfigurationV2() *corev1ac.PodTemplateSpecApplyConfi
 				WithImage(GetRayImage()).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1000m"),
-						corev1.ResourceMemory: resource.MustParse("3G"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1G"),
 					}))))
 }
 

--- a/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
+++ b/ray-operator/test/e2erayjob/rayjob_lightweight_test.go
@@ -46,7 +46,7 @@ env_vars:
 						WithRayStartParams(map[string]string{
 							"dashboard-host": "0.0.0.0",
 							"num-gpus":       "4",
-							"num-cpus":       "8",
+							"num-cpus":       "4",
 							"resources":      `'{"R1": 4}'`,
 						}).
 						WithTemplate(PodTemplateSpecApplyConfiguration(HeadPodTemplateApplyConfiguration(),

--- a/ray-operator/test/support/support.go
+++ b/ray-operator/test/support/support.go
@@ -146,12 +146,12 @@ func HeadPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigura
 				).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("6G"),
+						corev1.ResourceCPU:    resource.MustParse("300m"),
+						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("2000m"),
-						corev1.ResourceMemory: resource.MustParse("10G"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
 					}))))
 }
 
@@ -163,12 +163,12 @@ func WorkerPodTemplateApplyConfiguration() *corev1ac.PodTemplateSpecApplyConfigu
 				WithImage(GetRayImage()).
 				WithResources(corev1ac.ResourceRequirements().
 					WithRequests(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceCPU:    resource.MustParse("300m"),
 						corev1.ResourceMemory: resource.MustParse("1G"),
 					}).
 					WithLimits(corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1000m"),
-						corev1.ResourceMemory: resource.MustParse("3G"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("1G"),
 					}))))
 }
 


### PR DESCRIPTION
## Why are these changes needed?

RHOAIENG-77829: Release New Version of KubeRay 1.6.2 for ODH + restore test resources to match upstream + add CI to validate resources untouched

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-77829

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

## Architecture

- [ ] This PR does not change component boundaries or API contracts
- [ ] OR: I have updated the relevant design doc / DEVELOPMENT.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated the operator release pipeline and OpenShift configuration to use the newer v1.6.2 container image.

- **Tests**
  - Added automated checks to ensure resource-update scenarios produce the expected test changes.
  - Adjusted test workloads and pod resource settings to improve compatibility and reliability across autoscaling and lightweight RayJob scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->