### PR TITLE
RHOAIENG-78714: rewrite CI workflows to prevent from double execution of certain events

### DIFF
--- a/.github/workflows/odh-release.yml
+++ b/.github/workflows/odh-release.yml
@@ -1,18 +1,17 @@
-# This workflow will compile e2e tests and release them
+# Create a GitHub release for an ODH KubeRay version tag.
 
 name: ODH Release
 on:
+  # workflow_dispatch only: gh release create publishes a tag, and a push:tags
+  # trigger would re-enter this workflow and fail "Release already exists".
   workflow_dispatch:
     inputs:
       version:
         description: 'Tag to be used for release, i.e.: v0.0.1'
         required: true
-  push:
-    tags:
-      - '*'
 
 env:
-  KUBERAY_RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+  KUBERAY_RELEASE_VERSION: ${{ github.event.inputs.version }}
 
 jobs:
   release-odh:
@@ -24,12 +23,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Set Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: v1.22
-        cache-dependency-path: "ray-operator/go.sum"
 
     - name: Verify that release doesn't exist yet
       shell: bash {0}
@@ -43,14 +36,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.TOKEN }}
 
-    - name: Compile tests
-      run: |
-        go test -c -o compiled-tests/e2e ./test/e2e/
-      working-directory: ray-operator
-
     - name: Creates a release in GitHub
       run: |
-        gh release create $KUBERAY_RELEASE_VERSION --target $GITHUB_SHA ray-operator/compiled-tests/*
+        gh release create $KUBERAY_RELEASE_VERSION --target $GITHUB_SHA
       env:
         GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
       shell: bash

--- a/.tekton/odh-kuberay-operator-controller-push.yaml
+++ b/.tekton/odh-kuberay-operator-controller-push.yaml
@@ -11,8 +11,10 @@ metadata:
       == "stable"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: opendatahub-builds
-    appstudio.openshift.io/component: odh-kuberay-operator-controller-ci
+    # Build :odh-stable on the release component so stable pushes do not create
+    # CI-component snapshots that re-trigger kuberay-ci-its-manual (PR merge gate).
+    appstudio.openshift.io/application: opendatahub-release
+    appstudio.openshift.io/component: odh-kuberay-operator-controller
     pipelines.appstudio.openshift.io/type: build
   name: odh-kuberay-operator-controller-on-push
   namespace: open-data-hub-tenant


### PR DESCRIPTION
## Why are these changes needed?

Stops the Konflux PR e2e (kuberay-ci-its-manual) from re-running after merge by building :odh-stable on the release component instead of the CI component, while still retagging both :odh-stable and the version tag on stable pushes. Removes the ODH Release workflow’s push: tags self-trigger that caused a second failing run after a successful manual release. Also drops the obsolete e2e compile/upload steps from that release workflow so it only creates the GitHub release.

## Related issue number

https://redhat.atlassian.net/browse/RHOAIENG-78714

## Checks

- [ ] I've made sure the tests are passing.
- Testing Strategy
  - [ ] Unit tests
  - [ ] Manual tests
  - [ ] This PR is not tested :(

## Architecture

- [ ] This PR does not change component boundaries or API contracts
- [ ] OR: I have updated the relevant design doc / DEVELOPMENT.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Releases can now be initiated manually with a specified version.
  * GitHub releases are created from the selected commit without attaching compiled test artifacts.

* **Build Configuration**
  * Stable push builds are routed to the appropriate release application and component.
  * Added guidance clarifying that stable pushes should not trigger manual pull request merge gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->