### PR TITLE
RHOAIENG-78118: switch webhook TLS from OpenShift serving-certs to cert-manager

### DIFF
--- a/ray-operator/config/openshift/certmanager.yaml
+++ b/ray-operator/config/openshift/certmanager.yaml
@@ -1,0 +1,27 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: $(namespace)
+  labels:
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: certificate
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+  namespace: $(namespace)
+  labels:
+    app.kubernetes.io/name: kuberay
+    app.kubernetes.io/component: certificate
+spec:
+  dnsNames:
+    - kuberay-webhook-service.$(namespace).svc
+    - kuberay-webhook-service.$(namespace).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: kuberay-webhook-server-cert

--- a/ray-operator/config/openshift/kustomization.yaml
+++ b/ray-operator/config/openshift/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
 - ray_operator_scc.yaml
 - ../default
 - webhook.yaml
+- certmanager.yaml
 - ../overlays/odh/rbac/tls
 
 commonLabels:

--- a/ray-operator/config/openshift/webhook.yaml
+++ b/ray-operator/config/openshift/webhook.yaml
@@ -4,8 +4,6 @@ kind: Service
 metadata:
   name: kuberay-webhook-service
   namespace: $(namespace)
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: kuberay-webhook-server-cert
   labels:
     app.kubernetes.io/name: kuberay
     app.kubernetes.io/component: webhook
@@ -23,7 +21,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: kuberay-mutating-webhook-configuration
   annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
+    cert-manager.io/inject-ca-from: $(namespace)/serving-cert
 webhooks:
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
## Why are these changes needed?

The `openshift/` overlay currently uses OpenShift serving-cert annotations
(`service.beta.openshift.io/serving-cert-secret-name`, `service.beta.openshift.io/inject-cabundle`)
for webhook TLS. The platform is moving to cert-manager as the standard TLS
mechanism across all module operators. This PR swaps the webhook TLS to
cert-manager so that `ray-module-operator` (and eventually the ODH operator's
in-tree path) can deploy webhooks without depending on OpenShift-specific
serving-cert infrastructure.

### Changes

- **`webhook.yaml`**: Remove `service.beta.openshift.io/serving-cert-secret-name`
  from the Service. Replace `service.beta.openshift.io/inject-cabundle` on the
  MutatingWebhookConfiguration with `cert-manager.io/inject-ca-from`.
- **`certmanager.yaml`** (new): Self-signed `Issuer` + `Certificate` with
  `secretName: kuberay-webhook-server-cert` (matches existing volume mount in
  `webhook-deployment-patch.yaml`) and namespace-parameterized `dnsNames`.
- **`kustomization.yaml`**: Add `certmanager.yaml` to `resources:`.

No changes to `params.yaml` — it already has `varReference` entries for
`spec/dnsNames` on Certificate and `cert-manager.io/inject-ca-from` on
MutatingWebhookConfiguration.

## Related issue number

RHOAIENG-78118

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Manual tests
  - `kustomize build config/openshift/` renders clean YAML with cert-manager
    annotations, no serving-cert annotations, no ValidatingWebhookConfiguration,
    no Namespace resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated TLS certificate provisioning for the KubeRay webhook service on OpenShift.
  * Configured secure webhook communication using cert-manager-issued certificates and CA injection.

* **Configuration**
  * Updated OpenShift deployment resources to include the new certificate and issuer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->