### PR TITLE
fix(openshift): scope kuberay informers to application namespace (RHOAIENG-87678)

### DIFF
--- a/ray-operator/config/openshift/tls-metrics-patch.yaml
+++ b/ray-operator/config/openshift/tls-metrics-patch.yaml
@@ -8,6 +8,8 @@ spec:
       containers:
       - name: kuberay-operator
         args:
+        - --feature-gates=RayClusterStatusConditions=true
+        - --watch-namespace=$(namespace)
         - --metrics-cert-path=/etc/metrics-certs
         ports:
         - name: https


### PR DESCRIPTION
## Description

Adds `--watch-namespace=$(namespace)` to the kuberay-operator deployment in the OpenShift kustomize overlay (`tls-metrics-patch.yaml`). This scopes all kuberay informers to the application namespace instead of watching cluster-wide.

The kuberay-operator already supports `--watch-namespace` upstream — this change simply enables it in the ODH/RHOAI deployment manifests.

## Why

On high-namespace clusters (e.g. Developer Sandbox with 2000+ namespaces), cluster-wide informers for Pods, Services, and ServiceAccounts cause unnecessary apiserver memory pressure. The kuberay-operator only manages Ray resources in the application namespace, so scoping the informers is safe and has no functional impact.

See [RHOAIENG-87678](https://redhat.atlassian.net/browse/RHOAIENG-87678) and the parent audit [RHOAIENG-83245](https://redhat.atlassian.net/browse/RHOAIENG-83245).

## Changes

1 file changed, 2 insertions: added `--feature-gates` and `--watch-namespace` to the existing `tls-metrics-patch.yaml` args list (the tls-metrics patch already sets args via strategic merge, so the watch-namespace flag is added there to avoid being overwritten).

## Testing

- `kustomize build ray-operator/config/openshift/` — verified output contains all 3 args
- No code changes — manifest-only fix

[RHOAIENG-87678]: https://redhat.atlassian.net/browse/RHOAIENG-87678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-83245]: https://redhat.atlassian.net/browse/RHOAIENG-83245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled enhanced Ray cluster status condition reporting.
  * Improved monitoring by automatically watching the configured namespace.

* **Bug Fixes**
  * Improved deployment configuration to ensure status updates are tracked within the intended namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->